### PR TITLE
Snackbar types fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/data-grid": "^4.0.0-alpha.19",

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -9,7 +9,7 @@ export interface SnackbarProps extends MuiSnackbarProps {
     vertical: 'bottom' | 'top';
   };
   autoHideDuration?: number;
-  color?: 'success' | 'info' | 'warning' | 'error' | undefined;
+  color?: 'success' | 'info' | 'warning' | 'error';
   direction?: 'right' | 'left' | 'up' | 'down';
   severity?: 'success' | 'info' | 'warning' | 'error';
   variant?: 'standard' | 'filled' | 'outlined';

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -4,15 +4,15 @@ import Slide from '@material-ui/core/Slide';
 import { TransitionProps } from '@material-ui/core/transitions';
 
 export interface SnackbarProps extends MuiSnackbarProps {
-  anchorOrigin: {
+  anchorOrigin?: {
     horizontal: 'center' | 'left' | 'right';
     vertical: 'bottom' | 'top';
   };
-  autoHideDuration: number;
-  color?: 'success' | 'info' | 'warning' | 'error';
-  direction: 'right' | 'left' | 'up' | 'down';
-  severity: 'success' | 'info' | 'warning' | 'error';
-  variant: 'standard' | 'filled' | 'outlined';
+  autoHideDuration?: number;
+  color?: 'success' | 'info' | 'warning' | 'error' | undefined;
+  direction?: 'right' | 'left' | 'up' | 'down';
+  severity?: 'success' | 'info' | 'warning' | 'error';
+  variant?: 'standard' | 'filled' | 'outlined';
 }
 
 const Snackbar = ({
@@ -29,12 +29,10 @@ const Snackbar = ({
 }: SnackbarProps): JSX.Element => {
   return (
     <MuiSnackbar
-      {...props}
       anchorOrigin={anchorOrigin}
       autoHideDuration={autoHideDuration}
-      TransitionComponent={(params: TransitionProps) => (
-        <Slide {...params} direction={direction} />
-      )}>
+      TransitionComponent={(params: TransitionProps) => <Slide {...params} direction={direction} />}
+      {...props}>
       <div>
         <AlertBase color={color} severity={severity} variant={variant}>
           {props.message}


### PR DESCRIPTION
- Make props, which have default value optional.
- Move rest operator, so it is possible to overwrite default props for `anchorOrigin`, `autoHideDuration` and `TransitionComponent`.