### PR TITLE
Fix spreading rest of props

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -37,7 +37,6 @@ const Button = ({
       variant={variant}
       color={color}
       disabled={disabled}
-      {...props}
       sx={{
         borderRadius: '3px',
         padding: chunky ? '15px 23px' : '5px 15px',
@@ -116,6 +115,7 @@ const Button = ({
           },
         },
       }}
+      {...props}
     >
       {children}
     </MuiButton>

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -2,9 +2,10 @@ import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatepickerProps } fr
 import Calendar from '../icons/Calendar';
 import TextField, { ColorTypes, TextFieldProps } from './TextField';
 
-export interface DatePickerProps<TDate> extends MuiDatepickerProps<TDate> {
+export interface DatePickerProps<TDate> extends Omit<MuiDatepickerProps<TDate>, 'renderInput'> {
   color?: ColorTypes;
   allowAllYears?: boolean;
+  renderInput?: MuiDatepickerProps['renderInput'];
 }
 
 const isDisallowedYear = (date: Date) => {
@@ -70,10 +71,10 @@ const DatePicker = ({
       }}
       shouldDisableYear={!allowAllYears ? isDisallowedYear : undefined}
       showDaysOutsideCurrentMonth={showDaysOutsideCurrentMonth}
-      {...props}
       renderInput={(params) => {
         return <TextField {...(params as TextFieldProps)} color={color} />;
       }}
+      {...props}
     />
   );
 };

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -2,10 +2,9 @@ import { DatePicker as MuiDatePicker, DatePickerProps as MuiDatepickerProps } fr
 import Calendar from '../icons/Calendar';
 import TextField, { ColorTypes, TextFieldProps } from './TextField';
 
-export interface DatePickerProps<TDate> extends Omit<MuiDatepickerProps<TDate>, 'renderInput'> {
+export interface DatePickerProps<TDate> extends MuiDatepickerProps<TDate> {
   color?: ColorTypes;
   allowAllYears?: boolean;
-  renderInput?: MuiDatepickerProps['renderInput'];
 }
 
 const isDisallowedYear = (date: Date) => {
@@ -71,10 +70,10 @@ const DatePicker = ({
       }}
       shouldDisableYear={!allowAllYears ? isDisallowedYear : undefined}
       showDaysOutsideCurrentMonth={showDaysOutsideCurrentMonth}
+      {...props}
       renderInput={(params) => {
         return <TextField {...(params as TextFieldProps)} color={color} />;
       }}
-      {...props}
     />
   );
 };

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,18 +1,11 @@
 import { OptionsType } from './Autocomplete';
 import { Globe } from '../icons';
-import Select, { SelectProps } from './Select';
+import Select, { SingleSelectProps } from './Select';
 
-export type LanguageSelectProps<T = OptionsType> = Omit<SelectProps, 'adornment' | 'multiple'> & {
-  options: T[];
-  helperText?: string;
-  error?: boolean;
-  'data-testid'?: string;
-};
+export type LanguageSelectProps = Omit<SingleSelectProps, 'adornment' | 'multiple'>;
 
-const LanguageSelector = ({ options, ...props }: LanguageSelectProps): JSX.Element => {
-  return (
-    <Select {...(props as SelectProps)} adornment={<Globe fontSize="small" />} options={options} />
-  );
+const LanguageSelector = ({ ...props }: LanguageSelectProps): JSX.Element => {
+  return <Select multiple={false} adornment={<Globe fontSize="small" />} {...props} />;
 };
 
 export default LanguageSelector;

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -21,10 +21,10 @@ const Progress = ({
   return (
     <>
       {type === 'circular' && (
-        <CircularProgress {...props} color={color} size={size} value={value} variant={variant} />
+        <CircularProgress color={color} size={size} value={value} variant={variant} {...props} />
       )}
       {type === 'linear' && (
-        <LinearProgress {...props} color={color} value={value} variant={variant} />
+        <LinearProgress color={color} value={value} variant={variant} {...props} />
       )}
     </>
   );

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -2,28 +2,32 @@ import { Search as SearchIcon } from '../icons';
 import TextField, { TextFieldProps } from './TextField';
 import Autocomplete, { AutocompleteProps, OptionsType } from './Autocomplete';
 
-export type SearchProps<T = OptionsType> = (
-  | Omit<
-      AutocompleteProps<T>,
-      'adornment' | 'filterSelectedOptions' | 'getOptionLabel' | 'multiple'
-    >
-  | Omit<
-      TextFieldProps,
-      'endAdornment' | 'getOptionLabel' | 'hiddenLabel' | 'startAdornment' | 'variant'
-    >
-) & {
-  freeSolo?: boolean;
-  options?: T[];
+export type SingleOptionSearchProps = Omit<
+  TextFieldProps,
+  'endAdornment' | 'getOptionLabel' | 'hiddenLabel' | 'startAdornment' | 'variant'
+>;
+
+export type MultipleOptionsSearchProps = Omit<
+  AutocompleteProps<OptionsType>,
+  'adornment' | 'filterSelectedOptions' | 'getOptionLabel' | 'multiple' | 'options'
+> & {
+  options?: AutocompleteProps['options'];
 };
 
-const Search = ({ freeSolo = true, ...props }: SearchProps): JSX.Element => {
+export type SearchProps = MultipleOptionsSearchProps | SingleOptionSearchProps;
+
+const Search = ({ ...props }: SearchProps): JSX.Element => {
   const searchIcon = <SearchIcon fontSize="small" />;
+
+  const { freeSolo = true, options = [], ...multiProps } = props as MultipleOptionsSearchProps;
+  const singleProps = props as SingleOptionSearchProps;
+
   if ((props as AutocompleteProps).options?.length) {
     return (
-      <Autocomplete {...(props as AutocompleteProps)} adornment={searchIcon} freeSolo={freeSolo} />
+      <Autocomplete adornment={searchIcon} freeSolo={freeSolo} options={options} {...multiProps} />
     );
   }
-  return <TextField {...(props as TextFieldProps)} startAdornment={searchIcon} />;
+  return <TextField startAdornment={searchIcon} {...singleProps} />;
 };
 
 export default Search;

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -2,15 +2,21 @@ import { MenuItem } from '@mui/material';
 import TextField, { TextFieldProps } from './TextField';
 import Autocomplete, { AutocompleteProps, OptionsType } from './Autocomplete';
 
-export type SelectProps<T = OptionsType> = (
-  | AutocompleteProps<T>
-  | Omit<TextFieldProps, 'startAdornment' | 'endAdornment' | 'variant'>
-) & {
-  options: OptionsType[];
-  adornment?: AutocompleteProps<T>['adornment'];
+type CommonProps = {
+  options?: AutocompleteProps['options'];
+  adornment?: AutocompleteProps<OptionsType>['adornment'];
   multiple?: boolean;
   'data-testid'?: string;
 };
+
+export type MultipleSelectProps = Omit<AutocompleteProps, 'options'> & CommonProps;
+export type SingleSelectProps = Omit<
+  TextFieldProps,
+  'startAdornment' | 'endAdornment' | 'variant'
+> &
+  CommonProps;
+
+export type SelectProps = MultipleSelectProps | SingleSelectProps;
 
 const Select = ({
   adornment,
@@ -22,16 +28,15 @@ const Select = ({
   if (multiple) {
     return (
       <Autocomplete
-        {...(props as AutocompleteProps)}
         multiple={multiple}
         options={options}
         disableClearable
+        {...(props as MultipleSelectProps)}
       />
     );
   }
   return (
     <TextField
-      {...(props as TextFieldProps)}
       select
       startAdornment={adornment}
       SelectProps={{
@@ -47,6 +52,7 @@ const Select = ({
         },
       }}
       inputProps={{ 'data-testid': testid }}
+      {...(props as SingleSelectProps)}
     >
       {options.map(({ id, value: label }) => (
         <MenuItem key={id} value={id}>

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -35,6 +35,7 @@ const Snackbar = ({
       TransitionComponent={(params: TransitionProps & { children: ReactElement<any, any> }) => (
         <Slide {...params} direction={direction} />
       )}
+      {...props}
     >
       <div>
         <AlertBase color={color} severity={severity} variant={variant}>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -5,12 +5,12 @@ export type TabProps = MuiTabProps;
 const Tab = (props: TabProps): JSX.Element => {
   return (
     <MuiTab
-      {...props}
       sx={{
         fontSize: '16px',
         '& .MuiTab.Mui-disabled': { color: 'text.disabled' },
         '&.MuiTab-wrapped': { fontSize: '13px' },
       }}
+      {...props}
     />
   );
 };

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -35,13 +35,13 @@ const TextField = ({
 
   return (
     <MuiTextField
+      variant='outlined'
       fullWidth={fullWidth}
       size={size}
       error={error}
       helperText={helperText}
       onClick={() => muiTextField.current?.focus()}
       inputRef={muiTextField}
-      {...props}
       InputProps={{
         endAdornment: endAdornment ? (
           <InputAdornment position="end">{endAdornment}</InputAdornment>
@@ -86,6 +86,7 @@ const TextField = ({
             color: overrideColor,
           },
       }}
+      {...props}
     />
   );
 };

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -22,7 +22,7 @@ export interface TypographyProps
 }
 
 const Typography = ({ variant = 'body1', ...props }: TypographyProps): JSX.Element => {
-  return <MuiTypography {...props} variant={variant} />;
+  return <MuiTypography variant={variant} {...props} />;
 };
 
 export default Typography;


### PR DESCRIPTION
I have noticed that some of our components are spreading rest of passed properties at the start of assigning them to component, some in the middle and some at the end. 
In my opinion having `{...props}` after all the other values is most flexible way as we are able to overwrite default values.

Some types fixes were also required.