### PR TITLE
overwrite function typing

### DIFF
--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -1,8 +1,20 @@
-import { Autocomplete as MuiAutocomplete } from '@mui/material';
+import { Autocomplete as MuiAutocomplete, ChipTypeMap } from '@mui/material';
 import { AutocompleteProps as MuiAutocompleteProps } from '@mui/material';
 import TextField, { SizeTypes, ColorTypes } from './TextField';
 import InputAdornment from './InputAdornment';
 import Chip from './Chip';
+
+declare module '@mui/material' {
+  interface AutocompleteProps<
+    T,
+    Multiple extends boolean | undefined,
+    DisableClearable extends boolean | undefined,
+    FreeSolo extends boolean | undefined,
+    ChipComponent extends React.ElementType = ChipTypeMap['defaultComponent']
+  > {
+    getOptionLabel?: (option: OptionsType) => string;
+  }
+}
 
 export type OptionsType = {
   id: number | string;


### PR DESCRIPTION
Finally with help of @grzegorz-bach I was able to reproduce locally issue existing in pipeline.

Turns out that with updating nextjs and eslint (#40), we have also updated MUI.  In current implementation of MUI Autocomplete component it is possible to create options from string array or custom option object as it was working before. Decided to support only creating options with objects as it was working before, but it required overwriting one of Autocomplete props types.