### PR TITLE
remove showDaysOutsideCurrentMonth default value change

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -16,7 +16,6 @@ const isDisallowedYear = (date: Date) => {
 
 const DatePicker = ({
   allowAllYears = false,
-  showDaysOutsideCurrentMonth = true,
   InputProps = { color: 'primary', id: 'datepicker' },
   ...props
 }: DatePickerProps<Date>): JSX.Element => {
@@ -70,7 +69,6 @@ const DatePicker = ({
         },
       }}
       shouldDisableYear={!allowAllYears ? isDisallowedYear : undefined}
-      showDaysOutsideCurrentMonth={showDaysOutsideCurrentMonth}
       {...props}
       renderInput={(params) => {
         return <TextField {...(params as TextFieldProps)} {...InputProps} />;

--- a/stories/Inputs/DatePicker.stories.tsx
+++ b/stories/Inputs/DatePicker.stories.tsx
@@ -61,16 +61,6 @@ Please install any of these date management libraries, @date-io adapter for it a
         },
       },
     },
-    showDaysOutsideCurrentMonth: {
-      control: { type: 'boolean' },
-      description: 'If true, days that have outsideCurrentMonth={true} are displayed.',
-      table: {
-        defaultValue: true,
-        type: {
-          summary: 'boolean',
-        },
-      },
-    },
   },
 } as Meta;
 


### PR DESCRIPTION
Addresses a usability issue that was found during NG alpha. 

When user selects a day that is from the next month ex.
March has a week that is
27 28 29 30 31 1 2
If the user clicks on 1st of April it will take them to the month of April and they have to click again the day 1st 

In this PR we change the default value of showDaysOutsideCurrentMonth as don't want to show days from previous/next month.

