### PR TITLE
NG-744

### DIFF
--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -10,17 +10,11 @@ const TimePicker = ({ ampm = false, InputProps = {}, ...props }: TimePickerProps
   return (
     <MuiTimePicker
       ampm={ampm}
+      open={false}
       {...props}
-      PopperProps={{
-        // @ts-ignore
+      OpenPickerButtonProps={{
         sx: {
-          '& .MuiClockPicker-arrowSwitcher': {
-            width: '70px',
-
-            '& button:hover': {
-              backgroundColor: 'primary.light',
-            },
-          },
+          pointerEvents: 'none',
         },
       }}
       renderInput={(params) => <TextField {...(params as TextFieldProps)} {...InputProps} />}

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -12,6 +12,11 @@ const TimePicker = ({ ampm = false, InputProps = {}, ...props }: TimePickerProps
       ampm={ampm}
       open={false}
       {...props}
+      InputAdornmentProps={{
+        sx: {
+          ml: '0px',
+        },
+      }}
       OpenPickerButtonProps={{
         sx: {
           pointerEvents: 'none',


### PR DESCRIPTION
Based on NG playdates, we decided to:

- Leave clock icon but disable clock UI selection
- fix .InputAdornment marginLeft: ﻿0 (to display the placeholder format text completely for am/pm as well)