### PR TITLE
NG-744-fix picking time on mobile device

### DIFF
--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -10,7 +10,6 @@ const TimePicker = ({ ampm = false, InputProps = {}, ...props }: TimePickerProps
   return (
     <MuiTimePicker
       ampm={ampm}
-      open={false}
       {...props}
       InputAdornmentProps={{
         sx: {


### PR DESCRIPTION
On desktop no clock selection popup is shown, but this PR enables it for mobile.