### PR TITLE
Add forwardRef to components Lyyti has noticed issues with

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,6 +1,7 @@
 import MuiDatePicker, { DatePickerProps as MuiDatepickerProps } from '@mui/lab/DatePicker';
 import Calendar from '../icons/Calendar';
 import TextField, { TextFieldProps } from './TextField';
+import { forwardRef, Ref } from 'react';
 
 export interface DatePickerProps<TDate>
   extends Omit<MuiDatepickerProps<TDate>, 'renderInput' | 'InputProps'> {
@@ -14,11 +15,14 @@ const isDisallowedYear = (date: Date) => {
   return year < 2006 || year > maxYear;
 };
 
-const DatePicker = ({
-  allowAllYears = false,
-  InputProps = { color: 'primary', id: 'datepicker' },
-  ...props
-}: DatePickerProps<Date>): JSX.Element => {
+const DatePicker = (
+  {
+    allowAllYears = false,
+    InputProps = { color: 'primary', id: 'datepicker' },
+    ...props
+  }: DatePickerProps<Date>,
+  ref: Ref<HTMLInputElement>
+): JSX.Element => {
   return (
     <MuiDatePicker
       components={{ OpenPickerIcon: (props) => Calendar({ fontSize: 'small', ...props }) }}
@@ -71,10 +75,10 @@ const DatePicker = ({
       shouldDisableYear={!allowAllYears ? isDisallowedYear : undefined}
       {...props}
       renderInput={(params) => {
-        return <TextField {...(params as TextFieldProps)} {...InputProps} />;
+        return <TextField {...(params as TextFieldProps)} {...InputProps} ref={ref} />;
       }}
     />
   );
 };
 
-export default DatePicker;
+export default forwardRef(DatePicker);

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -15,25 +15,26 @@ export type TextFieldProps = {
   error?: boolean;
   helperText?: string;
   'data-testid'?: string;
-  ref: Ref<HTMLInputElement>;
 } & Omit<
   OutlinedTextFieldProps,
   'variant' | 'color' | 'fullWidth' | 'error' | 'helperText' | 'hiddenLabel'
 >;
 
-const TextField = ({
-  endAdornment,
-  fullWidth = true,
-  size = 'small',
-  startAdornment,
-  color = 'primary',
-  error = false,
-  helperText = '',
-  sx = {},
-  InputLabelProps = {},
-  ref,
-  ...props
-}: TextFieldProps): JSX.Element => {
+const TextField = (
+  {
+    endAdornment,
+    fullWidth = true,
+    size = 'small',
+    startAdornment,
+    color = 'primary',
+    error = false,
+    helperText = '',
+    sx = {},
+    InputLabelProps = {},
+    ...props
+  }: TextFieldProps,
+  ref: Ref<HTMLInputElement>
+): JSX.Element => {
   const muiTextField = useRef<HTMLInputElement>(null);
   const overrideColor = color === 'white' ? 'common.white' : undefined;
 

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { forwardRef, Ref, useRef } from 'react';
 import { TextField as MuiTextField, OutlinedTextFieldProps } from '@mui/material';
 import InputAdornment from './InputAdornment';
 
@@ -15,6 +15,7 @@ export type TextFieldProps = {
   error?: boolean;
   helperText?: string;
   'data-testid'?: string;
+  ref: Ref<HTMLInputElement>;
 } & Omit<
   OutlinedTextFieldProps,
   'variant' | 'color' | 'fullWidth' | 'error' | 'helperText' | 'hiddenLabel'
@@ -30,6 +31,7 @@ const TextField = ({
   helperText = '',
   sx = {},
   InputLabelProps = {},
+  ref,
   ...props
 }: TextFieldProps): JSX.Element => {
   const muiTextField = useRef<HTMLInputElement>(null);
@@ -89,9 +91,10 @@ const TextField = ({
           },
         ...sx,
       }}
+      ref={ref}
       {...props}
     />
   );
 };
 
-export default TextField;
+export default forwardRef(TextField);

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -1,12 +1,16 @@
 import MuiTimePicker, { TimePickerProps as MuiTimePickerProps } from '@mui/lab/TimePicker';
 import TextField, { TextFieldProps } from './TextField';
+import { forwardRef, Ref } from 'react';
 
 export interface TimePickerProps extends Omit<MuiTimePickerProps, 'renderInput' | 'InputProps'> {
   InputProps?: TextFieldProps;
   'data-testid'?: string;
 }
 
-const TimePicker = ({ ampm = false, InputProps = {}, ...props }: TimePickerProps): JSX.Element => {
+const TimePicker = (
+  { ampm = false, InputProps = {}, ...props }: TimePickerProps,
+  ref: Ref<HTMLInputElement>
+): JSX.Element => {
   return (
     <MuiTimePicker
       ampm={ampm}
@@ -21,9 +25,11 @@ const TimePicker = ({ ampm = false, InputProps = {}, ...props }: TimePickerProps
           pointerEvents: 'none',
         },
       }}
-      renderInput={(params) => <TextField {...(params as TextFieldProps)} {...InputProps} />}
+      renderInput={(params) => (
+        <TextField {...(params as TextFieldProps)} {...InputProps} ref={ref} />
+      )}
     />
   );
 };
 
-export default TimePicker;
+export default forwardRef(TimePicker);


### PR DESCRIPTION
We've recently gotten console errors on missing forwardRefs with Datepicker, Textfield and Timepicker components

- Forwards refs and passes them to underlying TextField component