### PR TITLE
Update release description automatically

### DIFF
--- a/.github/workflows/deploy_storybook.yml
+++ b/.github/workflows/deploy_storybook.yml
@@ -3,8 +3,11 @@
 name: Deploy Storybook
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+    branches:
+      - 'main'
+    types:
+      - 'closed'
     paths:
       - 'src/**'
       - 'stories/**'
@@ -16,6 +19,7 @@ on:
 
 jobs:
   deploy:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           tag: ${{ env.TAG }}
           name: Release ${{ env.TAG }}
-          body: ${{ github.event.pull_request.pull_request.body }}
+          body: ${{ github.event.pull_request.body }}
         env:
           TAG: v${{ steps.package-version.outputs.current-version }}
 

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           tag: ${{ env.TAG }}
           name: Release ${{ env.TAG }}
+          body: ${{ github.event.pull_request.pull_request.body }}
         env:
           TAG: v${{ steps.package-version.outputs.current-version }}
 

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -3,8 +3,11 @@
 name: Publish Lyyti Design System
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+    branches:
+      - 'main'
+    types:
+      - 'closed'
     paths:
       - 'src/**'
       - 'public/**'
@@ -20,6 +23,7 @@ on:
 
 jobs:
   create-release:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -40,6 +44,7 @@ jobs:
           TAG: v${{ steps.package-version.outputs.current-version }}
 
   publish-npm:
+    if: github.event.pull_request.merged == true
     needs: create-release
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +62,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-github:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -54,30 +54,21 @@ as soon as possible.
 
 Please make sure that you use our ESLint and Prettier rules and always use Typescript.
 
-When you create a pull request with changes make sure to also bump the package.json version.
-Depending on what you have done run one of the following commands
+### Version bumping
 
-Bump patch version.
+When you create a pull request with changes make sure to also bump the package.json version with one of the commands below. If you are unsure which one you should bump, ask in your PR.
 
 ```shell
 npm --no-git-tag-version version patch # Goes from 1.0.0 -> 1.0.1
 ```
 
-Bump minor version.
+Or replace patch with minor (1.0.0 -> 1.1.0) or major (1.0.0 -> 2.0.0).
 
-```shell
-npm --no-git-tag-version version minor # Goes from 1.0.0 -> 1.1.0
-```
+### Release
 
-Bump major version.
+When your pull request is merged to `next`, you should make a release PR from `next` to `main`. Typically a release PR should have title of "Version 1.0.1" and the description list what changes are introduced.
 
-```shell
-npm --no-git-tag-version version major # Goes from 1.0.0 -> 2.0.0
-```
-
-If you are un sure which one you should bump ask in your PR.
-
-Our publishing is completely automated. As soon as something is merged to main a tag and release are created
+Our release process from there on is completely automated. As soon as a PR is merged to main a tag and release are created
 then that is published to the NPM registry.
 
 ## Get started


### PR DESCRIPTION
- Convert on push to main action to on PR merge to main
- Update release description with merged PRs description
- Clarify release process in README

pull_request event info [here](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request)

pull_request.pull_request content seems to be same as [the API response](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request) based on the docs