### PR TITLE
Align chevron icons in the middle of svg viewbox

### DIFF
--- a/src/icons/ChevronDown.tsx
+++ b/src/icons/ChevronDown.tsx
@@ -11,7 +11,7 @@ const ChevronDown = (props: any) =>
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={1.5}
-      d="M21.29.75L11.02 11.02.75.75"
+      d="M22.3,6.9L12,17.1L1.7,6.9"
     />
   );
 

--- a/src/icons/ChevronLeft.tsx
+++ b/src/icons/ChevronLeft.tsx
@@ -11,7 +11,7 @@ const ChevronLeft = (props: any) =>
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={1.5}
-      d="M11.02 21.29L.75 11.02 11.02.75"
+      d="M17.1,22.3L6.9,12L17.1,1.7"
     />
   );
 

--- a/src/icons/ChevronRight.tsx
+++ b/src/icons/ChevronRight.tsx
@@ -11,7 +11,7 @@ const ChevronRight = (props: any) =>
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={1.5}
-      d="M.75.75l10.27 10.27L.75 21.29"
+      d="M6.9,1.7L17.1,12L6.9,22.3"
     />
   );
 

--- a/src/icons/ChevronUp.tsx
+++ b/src/icons/ChevronUp.tsx
@@ -11,7 +11,7 @@ const ChevronUp = (props: any) =>
       strokeLinecap="round"
       strokeLinejoin="round"
       strokeWidth={1.5}
-      d="M.75 11.02L11.02.75l10.27 10.27"
+      d="M1.7,17.1L12,6.9l10.3,10.3"
     />
   );
 


### PR DESCRIPTION
Previously the chevron icons were at the top left corner which made them look weird in the UI

Thanks to Asko for providing the SVG paths!