### PR TITLE
Allow JSX.element for Card title

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -7,8 +7,8 @@ import {
 } from '@mui/material';
 
 export interface CardProps
-  extends Omit<MuiCardProps, 'elevation' | 'raised' | 'square' | 'variant'> {
-  title?: string;
+  extends Omit<MuiCardProps, 'elevation' | 'raised' | 'square' | 'variant' | 'title'> {
+  title?: JSX.Element | string;
   subheader?: JSX.Element | string;
   headerAction?: JSX.Element;
   headerAvatar?: JSX.Element;


### PR DESCRIPTION
This is done so that we can set the title to be a JSX element or a React component instead of just a string.