### PR TITLE
Allow overriding default sx properties in Link component

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -30,6 +30,7 @@ const Link = (props: LinkProps): JSX.Element => {
             color: 'primary.light',
           },
         },
+        ...props.sx
       }}
       {...props}
     />

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -7,7 +7,6 @@ export interface LinkProps extends MuiLinkProps {
 const Link = ({ sx, ...props }: LinkProps): JSX.Element => {
   return (
     <MuiLink
-      {...props}
       sx={{
         color: 'primary.light',
         fontSize: '16px',
@@ -33,6 +32,7 @@ const Link = ({ sx, ...props }: LinkProps): JSX.Element => {
         },
         ...sx
       }}
+      {...props}
     />
   );
 };

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -7,6 +7,7 @@ export interface LinkProps extends MuiLinkProps {
 const Link = (props: LinkProps): JSX.Element => {
   return (
     <MuiLink
+      {...props}
       sx={{
         color: 'primary.light',
         fontSize: '16px',
@@ -32,7 +33,6 @@ const Link = (props: LinkProps): JSX.Element => {
         },
         ...props.sx
       }}
-      {...props}
     />
   );
 };

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -4,7 +4,7 @@ export interface LinkProps extends MuiLinkProps {
   'data-testid'?: string;
 }
 
-const Link = (props: LinkProps): JSX.Element => {
+const Link = ({ sx, ...props }: LinkProps): JSX.Element => {
   return (
     <MuiLink
       {...props}
@@ -31,7 +31,7 @@ const Link = (props: LinkProps): JSX.Element => {
             color: 'primary.light',
           },
         },
-        ...props.sx
+        ...sx
       }}
     />
   );


### PR DESCRIPTION
Added a spread operator to sx prop. sx={{ ..., ...props.sx }}