### PR TITLE
Combine npm and github package jobs, set scope explicitly

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -44,7 +44,7 @@ jobs:
         env:
           TAG: v${{ steps.package-version.outputs.current-version }}
 
-  publish-npm:
+  publish-package:
     if: github.event.pull_request.merged == true
     needs: create-release
     runs-on: ubuntu-latest
@@ -54,30 +54,20 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - name: Build and Publish
+      - name: Build package
         run: |
           npm ci
           npm run build
-          npm publish ./dist
+      - name: Publish npm
+        run: npm publish ./dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  publish-github:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: 16
-          registry-url: 'https://npm.pkg.github.com'
-      - run: npm ci
-      - run: |
-          npm ci
-          npm run build
-          npm publish ./dist
+          registry-url: https://npm.pkg.github.com
+          scope: '@lyytioy'
+      - name: Publish Github
+        run: npm publish ./dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Trying out if explicitly setting the scope + removing quotes around the registry-url helps. Also combining the job with the npm package publish so we install dependencies + build only once

Inspiration from [setup-node docs](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publish-to-npmjs-and-gpr-with-npm)