### PR TITLE
@mui/lab to @mui/x-date-pickers transition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.7.1",
@@ -14,7 +14,8 @@
         "@mui/lab": "^5.0.0-alpha.67",
         "@mui/material": "^5.3.0",
         "@mui/styles": "^5.3.0",
-        "@mui/x-data-grid": "^5.3.0"
+        "@mui/x-data-grid": "^5.3.0",
+        "@mui/x-date-pickers": "^5.0.0-alpha.5"
       },
       "devDependencies": {
         "@babel/core": "^7.16.10",
@@ -2781,6 +2782,53 @@
         }
       }
     },
+    "node_modules/@mui/lab/node_modules/@mui/x-date-pickers": {
+      "version": "5.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.1.tgz",
+      "integrity": "sha512-dLPkRiIn2Gr0momblxiOnIwrxn4SijVix+8e08mwAGWhiWcmWep1O9XTRDpZsjB0kjHYCf+kZjlRX4dxnj2acg==",
+      "dependencies": {
+        "@date-io/date-fns": "^2.11.0",
+        "@date-io/dayjs": "^2.11.0",
+        "@date-io/luxon": "^2.11.1",
+        "@date-io/moment": "^2.11.0",
+        "@mui/utils": "^5.6.0",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.4.2",
+        "rifm": "^0.12.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.2.3",
+        "@mui/system": "^5.2.3",
+        "date-fns": "^2.25.0",
+        "dayjs": "^1.10.7",
+        "luxon": "^1.28.0 || ^2.0.0",
+        "moment": "^2.29.1",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.8.2.tgz",
@@ -3020,15 +3068,16 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "5.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.1.tgz",
-      "integrity": "sha512-dLPkRiIn2Gr0momblxiOnIwrxn4SijVix+8e08mwAGWhiWcmWep1O9XTRDpZsjB0kjHYCf+kZjlRX4dxnj2acg==",
+      "version": "5.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.6.tgz",
+      "integrity": "sha512-2JeagDwwa/V2XPj243cZg5ReZ2553OzukUAfbdxXwj9gGGLeXjBa95NP4kPOBOze4tJq1y/4aYt/aK50aZWElQ==",
       "dependencies": {
-        "@date-io/date-fns": "^2.11.0",
-        "@date-io/dayjs": "^2.11.0",
-        "@date-io/luxon": "^2.11.1",
-        "@date-io/moment": "^2.11.0",
-        "@mui/utils": "^5.6.0",
+        "@babel/runtime": "^7.17.2",
+        "@date-io/date-fns": "^2.14.0",
+        "@date-io/dayjs": "^2.14.0",
+        "@date-io/luxon": "^2.14.0",
+        "@date-io/moment": "^2.14.0",
+        "@mui/utils": "^5.4.1",
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "react-transition-group": "^4.4.2",
@@ -3042,16 +3091,23 @@
         "url": "https://opencollective.com/mui"
       },
       "peerDependencies": {
-        "@mui/material": "^5.2.3",
-        "@mui/system": "^5.2.3",
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.4.1",
+        "@mui/system": "^5.4.1",
         "date-fns": "^2.25.0",
         "dayjs": "^1.10.7",
         "luxon": "^1.28.0 || ^2.0.0",
         "moment": "^2.29.1",
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
+        "react": "^17.0.2 || ^18.0.0"
       },
       "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
         "date-fns": {
           "optional": true
         },
@@ -26112,6 +26168,24 @@
         "react-is": "^17.0.2",
         "react-transition-group": "^4.4.2",
         "rifm": "^0.12.1"
+      },
+      "dependencies": {
+        "@mui/x-date-pickers": {
+          "version": "5.0.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.1.tgz",
+          "integrity": "sha512-dLPkRiIn2Gr0momblxiOnIwrxn4SijVix+8e08mwAGWhiWcmWep1O9XTRDpZsjB0kjHYCf+kZjlRX4dxnj2acg==",
+          "requires": {
+            "@date-io/date-fns": "^2.11.0",
+            "@date-io/dayjs": "^2.11.0",
+            "@date-io/luxon": "^2.11.1",
+            "@date-io/moment": "^2.11.0",
+            "@mui/utils": "^5.6.0",
+            "clsx": "^1.1.1",
+            "prop-types": "^15.7.2",
+            "react-transition-group": "^4.4.2",
+            "rifm": "^0.12.1"
+          }
+        }
       }
     },
     "@mui/material": {
@@ -26223,15 +26297,16 @@
       }
     },
     "@mui/x-date-pickers": {
-      "version": "5.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.1.tgz",
-      "integrity": "sha512-dLPkRiIn2Gr0momblxiOnIwrxn4SijVix+8e08mwAGWhiWcmWep1O9XTRDpZsjB0kjHYCf+kZjlRX4dxnj2acg==",
+      "version": "5.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-5.0.0-alpha.6.tgz",
+      "integrity": "sha512-2JeagDwwa/V2XPj243cZg5ReZ2553OzukUAfbdxXwj9gGGLeXjBa95NP4kPOBOze4tJq1y/4aYt/aK50aZWElQ==",
       "requires": {
-        "@date-io/date-fns": "^2.11.0",
-        "@date-io/dayjs": "^2.11.0",
-        "@date-io/luxon": "^2.11.1",
-        "@date-io/moment": "^2.11.0",
-        "@mui/utils": "^5.6.0",
+        "@babel/runtime": "^7.17.2",
+        "@date-io/date-fns": "^2.14.0",
+        "@date-io/dayjs": "^2.14.0",
+        "@date-io/luxon": "^2.14.0",
+        "@date-io/moment": "^2.14.0",
+        "@mui/utils": "^5.4.1",
         "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
         "react-transition-group": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@mui/lab": "^5.0.0-alpha.67",
     "@mui/material": "^5.3.0",
     "@mui/styles": "^5.3.0",
-    "@mui/x-data-grid": "^5.3.0"
+    "@mui/x-data-grid": "^5.3.0",
+    "@mui/x-date-pickers": "^5.0.0-alpha.5"
   },
   "devDependencies": {
     "@babel/core": "^7.16.10",

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -1,10 +1,13 @@
-import MuiDatePicker, { DatePickerProps as MuiDatepickerProps } from '@mui/lab/DatePicker';
+import {
+  DatePicker as MuiDatePicker,
+  DatePickerProps as MuiDatepickerProps,
+} from '@mui/x-date-pickers/DatePicker';
 import Calendar from '../icons/Calendar';
 import TextField, { TextFieldProps } from './TextField';
 import { forwardRef, Ref } from 'react';
 
 export interface DatePickerProps<TDate>
-  extends Omit<MuiDatepickerProps<TDate>, 'renderInput' | 'InputProps'> {
+  extends Omit<MuiDatepickerProps<TDate, TDate>, 'renderInput' | 'InputProps'> {
   allowAllYears?: boolean;
   InputProps?: TextFieldProps;
 }

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -1,14 +1,18 @@
-import MuiTimePicker, { TimePickerProps as MuiTimePickerProps } from '@mui/lab/TimePicker';
+import {
+  TimePicker as MuiTimePicker,
+  TimePickerProps as MuiTimePickerProps,
+} from '@mui/x-date-pickers/TimePicker';
 import TextField, { TextFieldProps } from './TextField';
 import { forwardRef, Ref } from 'react';
 
-export interface TimePickerProps extends Omit<MuiTimePickerProps, 'renderInput' | 'InputProps'> {
+export interface TimePickerProps<TDate>
+  extends Omit<MuiTimePickerProps<TDate, TDate>, 'renderInput' | 'InputProps'> {
   InputProps?: TextFieldProps;
   'data-testid'?: string;
 }
 
 const TimePicker = (
-  { ampm = false, InputProps = {}, ...props }: TimePickerProps,
+  { ampm = false, InputProps = {}, ...props }: TimePickerProps<Date>,
   ref: Ref<HTMLInputElement>
 ): JSX.Element => {
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export { default as Collapse } from '@mui/material/Collapse';
 export { default as Container } from '@mui/material/Container';
 export { default as DataGrid } from './components/DataGrid';
 export { default as DatePicker } from './components/DatePicker';
-export { default as LocalizationProvider } from '@mui/lab/LocalizationProvider';
+export { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 export { default as Dialog } from './components/Dialog';
 export { default as Divider } from '@mui/material/Divider';
 export { default as Drawer } from '@mui/material/Drawer';

--- a/stories/Inputs/TimePicker.stories.tsx
+++ b/stories/Inputs/TimePicker.stories.tsx
@@ -87,8 +87,8 @@ Please install any of these date management libraries, @date-io adapter for it a
   },
 } as Meta;
 
-const Template: Story<TimePickerProps> = (args) => {
-  const [value, setValue] = useState<unknown>(new Date());
+const Template: Story<TimePickerProps<Date>> = (args) => {
+  const [value, setValue] = useState<Date | null>(new Date());
 
   return (
     <Box sx={{ width: '150px' }}>


### PR DESCRIPTION
Separates just the package transition from #82 

> When clearing the value of a Timepicker it throws an error, "Cannot read properties of null (reading 'hour')"
Importing Timepicker and LocalizationProvider from "@mui/x-date-pickers" instead of "@mui/lab" fixed the problem.
This change has to be done at latest in July since "@mui/lab" will stop exporting Date and Timepickers in versions after July 2022.

Tested by locally linking to a project and things seemed to work in the same way with the @mui/lab components

**Breaking changes**
LocalizationProvider's prop `locale` is deprecated and replaced by `adapterLocale`