### PR TITLE
Add script for bumping versions easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Please make sure that you use our ESLint and Prettier rules and always use Types
 When you create a pull request with changes make sure to also bump the package.json version with one of the commands below. If you are unsure which one you should bump, ask in your PR.
 
 ```shell
-npm --no-git-tag-version version patch # Goes from 1.0.0 -> 1.0.1
+npm run bump patch # Goes from 1.0.0 -> 1.0.1
 ```
 
 Or replace patch with minor (1.0.0 -> 1.1.0) or major (1.0.0 -> 2.0.0).

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check-types": "tsc",
     "build-storybook": "npm ci && build-storybook -o docs-build",
     "build": "rm -rf dist/* && tsc --project tsconfig.release.json && cp -r src/fonts dist && cp -r src/styles dist && cp package.json dist && cp README.md dist",
+    "bump": "npm --no-git-tag-version version",
     "generate-icon": "npx @svgr/cli --typescript --template templateSvgIcon.ts -d src/icons --ext tsx $npm_config_path"
   },
   "resolutions": {


### PR DESCRIPTION
Previously you would have to copy the command from the README but now you have it easily available

You still need to provide the patch/minor/major argument for the command