### PR TITLE
Fix dialog close button positioning

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -35,7 +35,14 @@ const Button = (
     children.props.fontSize
   ) {
     return (
-      <IconButton ref={ref} color={buttonColor} disabled={disabled} size="large" {...props}>
+      <IconButton
+        ref={ref}
+        color={buttonColor}
+        disabled={disabled}
+        size="large"
+        sx={{ ...sx }}
+        {...props}
+      >
         {children}
       </IconButton>
     );


### PR DESCRIPTION
fix passing sx prop to the button, so the dialog close button can be positioned in the top right corner as desired 