### PR TITLE
Combine pull request templates so Github uses the one left by default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/general_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general_pr_template.md
@@ -1,5 +1,0 @@
-## Background
-Why are these changes needed? 
-
-## Description
-What changes are introduced?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,25 @@
+## Background
+
+Why are these changes needed?
+
 ## 💡 Feature 1
+
 - [Add new prop isReleased](https://github.com/lyytioy/lyyti-design-system/pull/{PR_NUMBER})
 - [Update story to describe usage](https://github.com/lyytioy/lyyti-design-system/pull/{PR_NUMBER})
 
 ## 🥏 Timeline component
+
 - [Add new Timeline component](https://github.com/lyytioy/lyyti-design-system/pull/{PR_NUMBER})
 
 ## 🛠 Fixes
+
 - [Fix Button ref typing](https://github.com/lyytioy/lyyti-design-system/pull/{PR_NUMBER})
 
 ## ⚠️ BREAKING CHANGES ⚠️
+
 - Button ref is now of type HTMLButtonElement instead of HTMLDivElement
+
+<!--
+Remove the parts you don't need. Good descriptions help maintain the repo
+Background should be in every PR except releases
+-->


### PR DESCRIPTION
## Background

With multiple pull request templates Github doesn't use any of them by default. Instead you need to provide the template name through query parameters like `https://github.com/lyytioy/lyyti-design-system/compare/main...next?quick_pull=1&template=release_pr_template.mds`

With a single pull request template in the base branch Github will prefill the pull request description with the template content

## 🛠 Fixes
- Deletes folder for pull request templates and combines the templates to one