### PR TITLE
Fix selectors and update color name

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -17,14 +17,14 @@ const Link = ({ sx, ...props }: LinkProps, ref: Ref<HTMLAnchorElement>): JSX.Ele
         '&.MuiLink-underlineHover': {
           '&:hover': {
             color: 'primary.main',
-            textDecorationColor: '#blue.100',
+            textDecorationColor: 'sky.100',
           },
           '&:active': {
             color: 'primary.light',
           },
         },
         '&.MuiLink-underlineAlways': {
-          textDecorationColor: 'blue.100',
+          textDecorationColor: 'sky.100',
           '&:hover': {
             color: 'primary.main',
           },

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -35,8 +35,8 @@ const Table = (
 
           '.MuiTableBody-root': {
             '.MuiTableRow-root': {
-              '&:nth-child(even)': { backgroundColor: 'light.light' },
-              '&:nth-child(odd)': { backgroundColor: color },
+              '&:nth-of-type(even)': { backgroundColor: 'light.light' },
+              '&:nth-of-type(odd)': { backgroundColor: color },
             },
           },
           ...sx,


### PR DESCRIPTION
## Background

- Getting error while running tests `The pseudo class ":nth-child" is potentially unsafe when doing server-side rendering. Try changing it to ":nth-of-type".`
- in last version  color `blue` was renamed to `sky`, but there were some references left
