### PR TITLE
Reexport usetheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,3 +70,4 @@ export { default as TableBody } from '@mui/material/TableBody';
 export { default as TableCell } from '@mui/material/TableCell';
 export { default as TableFooter } from '@mui/material/TableFooter';
 export { default as TableRow } from '@mui/material/TableRow';
+export { useTheme } from '@mui/system';

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,4 +71,3 @@ export { default as TableCell } from '@mui/material/TableCell';
 export { default as TableFooter } from '@mui/material/TableFooter';
 export { default as TableRow } from '@mui/material/TableRow';
 export { useTheme } from '@mui/system';
-export { default as theme } from './themes/theme';

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,3 +71,4 @@ export { default as TableCell } from '@mui/material/TableCell';
 export { default as TableFooter } from '@mui/material/TableFooter';
 export { default as TableRow } from '@mui/material/TableRow';
 export { useTheme } from '@mui/system';
+export { default as theme } from './themes/theme';


### PR DESCRIPTION
## Background
There are some cases where we can not refer to our theme through a string like `primary.main`, one example would be a component that is not a part of MUI, so it's our custom one or from the different library like `recharts`
