### PR TITLE
Dialog close button fix

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -35,6 +35,7 @@ const Dialog = (
       <MuiDialogTitle sx={{ pr: 8 }}>
         {dialogTitle}
         <Button
+          variant="icon"
           onClick={onClose as MouseEventHandler<HTMLButtonElement>}
           sx={{
             borderRadius: '50%',


### PR DESCRIPTION
## Background

After icon button detection improvements, the `Dialog` close button left untouched and needs to be adjusted.

<img width="955" alt="Screenshot 2022-08-18 at 13 22 17" src="https://user-images.githubusercontent.com/26175185/185383401-14197f50-88df-4212-82b9-6aee88f1dc4c.png">

## 🛠 Fixes

- Adjust `Dialog` close button
