### PR TITLE
NG-977 Update the error variant main colour

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -102,7 +102,7 @@ export default createTheme({
       contrastText: '#1F98CD',
     },
     error: {
-      main: '#D1492E',
+      main: '#CF482E',
       dark: '#A33924',
       light: '#F4A094',
       contrastText: '#FFFFFF',


### PR DESCRIPTION
## Background

The current `error.main` colour does not meet the WCAG criteria, so it has to be updated.

## 💡 Features

- New `error.main` colour, which meets the WCAG criteria
