### PR TITLE
Fix input props overriding issue

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -76,7 +76,8 @@ const DatePicker = <TInputDate = unknown, TDate = unknown>(
       shouldDisableYear={(year) => !allowAllYears ? isDisallowedYear(year) : false}
       {...props}
       renderInput={(params) => {
-        return <TextField {...(params as TextFieldProps)} {...InputProps} />;
+        const {inputProps, ...props} = InputProps;
+        return <TextField {...(params as TextFieldProps)} inputProps={{...params.inputProps, ...inputProps}} {...props} />;
       }}
     />
   );


### PR DESCRIPTION
## Background

Adding `inputProps` value into `InputProps` prop overrides all default inputProps which causes some issues.
For example adding `<DatePicker InputProps={{ inputProps: { placeholder: 'some placeholder' }} />` makes the datepicker's value always `null` 

## 🛠 Fixes

- fix inputProps overriding issue
