### PR TITLE
Timepicker input props fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.0.15",
+  "version": "1.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.0.15",
+      "version": "1.0.23",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.7.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -27,9 +27,10 @@ const TimePicker = <TDate = unknown>({ ampm = false, InputProps = {}, InputAdorn
         tabIndex: -1,
         ...OpenPickerButtonProps
       }}
-      renderInput={(params) => (
-        <TextField {...(params as TextFieldProps)} {...InputProps} />
-      )}
+      renderInput={(params) => {
+        const {inputProps, ...props} = InputProps;
+        return <TextField {...(params as TextFieldProps)} inputProps={{...params.inputProps, ...inputProps}} {...props} />;
+      }}
     />
   );
 };


### PR DESCRIPTION
## Background

Adding inputProps value into InputProps prop overrides all default inputProps which causes some issues.
For example adding <TimePicker InputProps={{ inputProps: { placeholder: 'some placeholder' }} /> makes the timepicker's value always null

## 🛠 Fixes

- fix inputProps overriding issue
