### PR TITLE
Pass freeSolo prop to Autocomplete

### DIFF
--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -49,6 +49,7 @@ const Autocomplete = (
     getOptionLabel = (option: OptionsType) => option.value,
     label,
     size = 'medium',
+    freeSolo = false,
     options,
     multiple = false,
     placeholder,
@@ -68,6 +69,7 @@ const Autocomplete = (
       getOptionLabel={getOptionLabel}
       options={options}
       multiple={multiple}
+      freeSolo={freeSolo}
       ref={ref}
       sx={{
         option: {


### PR DESCRIPTION
## Background

https://user-images.githubusercontent.com/33721570/195794235-e42f40b9-b7cd-4570-85f7-aaba7a3f52cb.mov

The `Search` component passes the `freeSolo` prop to `Autocomplete` but currently it gets passed directly to `TextField` which has no effect and just produces an error as the dom element input doesn't recognise attribute `freeSolo`.

The `freeSolo` prop allows to pass values that do not match any of the given options, currently doing this produces an error `getOptionLabel` method of Autocomplete returned undefined instead of a string`.

Why are these changes needed?

## 🛠 Fixes

- Pass freeSolo prop to Autocomplete to allow values that don't match any of the given options
