### PR TITLE
Make introduction page the default page

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -22,6 +22,7 @@ export const parameters = {
     storySort: {
       method: 'alphabetical',
       order: [
+        'Introduction',
         'Components',
         ['Layout', 'Inputs', 'Navigation', 'Surfaces', 'Feedback', 'Data Display'],
       ],


### PR DESCRIPTION
## Background

Fixes #23
When opening storybook it would default to the first story in the components section. The introduction page was meant to be the default page but we didn't figure out a good way to achieve that. It just hit me when working on the design system that you could propably just change the sorting and fix this (not sure how I didn't get this earlier)

## 📚 Fixes

- Makes Introduction the default page in Storybook
