### PR TITLE
NG-1340 Text button redesign

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -52,7 +52,7 @@ const Button = (
   }
 
   const containedPrimary = {
-    boxShadow: containedBoxShadow,
+    boxShadow: 'none',
     '&::before': {
       backgroundColor: 'primary.dark',
     },
@@ -69,7 +69,7 @@ const Button = (
   };
 
   const containedSecondary = {
-    boxShadow: containedBoxShadow,
+    boxShadow: 'none',
     '&::before': {
       backgroundColor: 'secondary.dark',
     },
@@ -86,7 +86,7 @@ const Button = (
   };
 
   const containedDanger = {
-    boxShadow: containedBoxShadow,
+    boxShadow: 'none',
     '&::before': {
       backgroundColor: 'error.dark',
     },
@@ -103,7 +103,6 @@ const Button = (
   };
 
   const outlinedPrimary = {
-    boxShadow: containedBoxShadow,
     '&::before': {
       backgroundColor: 'primaryStates.hover',
     },
@@ -121,7 +120,6 @@ const Button = (
   };
 
   const outlinedSecondary = {
-    boxShadow: containedBoxShadow,
     '&::before': {
       backgroundColor: 'secondaryStates.hover',
     },
@@ -139,7 +137,6 @@ const Button = (
   };
 
   const outlinedDanger = {
-    boxShadow: containedBoxShadow,
     '&::before': {
       backgroundColor: 'errorStates.hover',
     },
@@ -157,7 +154,6 @@ const Button = (
   };
 
   const textPrimary = {
-    boxShadow: containedBoxShadow,
     '&::before': {
       backgroundColor: 'primaryStates.hover',
     },
@@ -173,7 +169,6 @@ const Button = (
   };
 
   const textSecondary = {
-    boxShadow: containedBoxShadow,
     '&::before': {
       backgroundColor: 'secondaryStates.hover',
     },
@@ -189,7 +184,6 @@ const Button = (
   };
 
   const textDanger = {
-    boxShadow: containedBoxShadow,
     '&::before': {
       backgroundColor: 'errorStates.hover',
     },
@@ -219,15 +213,19 @@ const Button = (
         width: '0%',
         right: 0,
         position: 'absolute',
-        transition: 'width 500ms cubic-bezier(0.645, 0.045, 0.355, 1.000)',
+        boxShadow: 'none',
+        transition:
+          'width 500ms cubic-bezier(0.645, 0.045, 0.355, 1.000), boxShadow 500ms cubic-bezier(0.645, 0.045, 0.355, 1.000)',
         zIndex: -1,
         borderRadius: '3px',
       },
       '&:hover': {
         '&::before': {
           width: '100%',
+          boxShadow: containedBoxShadow,
         },
       },
+      '&:active': { boxShadow: containedBoxShadow },
       '&.MuiButton-containedPrimary': containedPrimary,
       '&.MuiButton-containedSecondary': containedSecondary,
       '&.MuiButton-containedError': containedDanger,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -213,9 +213,9 @@ const Button = (
         width: '0%',
         right: 0,
         position: 'absolute',
-        boxShadow: 'none',
-        transition:
-          'width 500ms cubic-bezier(0.645, 0.045, 0.355, 1.000), boxShadow 500ms cubic-bezier(0.645, 0.045, 0.355, 1.000)',
+        transitionProperty: 'width, box-shadow',
+        transitionDuration: '500ms',
+        transitionTimingFunction: 'cubic-bezier(0.645, 0.045, 0.355, 1.000)',
         zIndex: -1,
         borderRadius: '3px',
       },


### PR DESCRIPTION
## Background

Text button was redesigned to make the button hierarchy more clear and simultaneously the other variant's box shadows were adjusted. All buttons have box shadow only in hover and active states (not in default/disabled). Related to design work done in https://lyytidev.atlassian.net/browse/NG-1340

## 🛠 Fixes

- Removes box shadow from all variants in default and disabled states. Makes box shadow to use transition to make it appear together with hover effect.
