### PR TITLE
Use direct classNames

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,9 +1,4 @@
-import {
-  Button as MuiButton,
-  buttonClasses,
-  ButtonProps as MuiButtonProps,
-  IconButton,
-} from '@mui/material';
+import { Button as MuiButton, ButtonProps as MuiButtonProps, IconButton } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import { forwardRef, Ref } from 'react';
 import { LoadingButton } from '@mui/lab';
@@ -235,10 +230,10 @@ const Button = (
       '&.MuiButton-textPrimary': textPrimary,
       '&.MuiButton-textSecondary': textSecondary,
       '&.MuiButton-textError': textDanger,
-      [`& .${buttonClasses.startIcon} > *:nth-of-type(1)`]: {
+      [`& .MuiButton-startIcon > *:nth-of-type(1)`]: {
         fontSize: chunky ? '20px' : '16px',
       },
-      [`& .${buttonClasses.endIcon} > *:nth-of-type(1)`]: {
+      [`& .MuiButton-endIcon > *:nth-of-type(1)`]: {
         fontSize: chunky ? '20px' : '16px',
       },
       ...sx,


### PR DESCRIPTION
## Background

To unify code, using direct classNames similar to others.

## 🛠 Fixes

- Fix class name usage to use direct classNames
