### PR TITLE
use hover color for icon button hovers

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -31,6 +31,38 @@ const Button = (
   const theme = useTheme();
   const buttonColor = color === 'danger' ? 'error' : color;
 
+  const iconPrimary = {
+    '&::before': {
+      backgroundColor: 'primary.dark',
+    },
+    '&:hover': {
+      backgroundColor: 'primaryStates.hover',
+    },
+    '&:active': {
+      backgroundColor: 'primaryStates.activeContained',
+    },
+    '&.Mui-disabled': {
+      backgroundColor: 'primaryStates.disabledBg',
+      color: 'primary.contrastText',
+    },
+  };
+
+  const iconSecondary = {
+    '&::before': {
+      backgroundColor: 'secondary.dark',
+    },
+    '&:hover': {
+      backgroundColor: 'secondaryStates.hover',
+    },
+    '&:active': {
+      backgroundColor: 'secondaryStates.activeContained',
+    },
+    '&.Mui-disabled': {
+      backgroundColor: 'secondaryStates.disabledBg',
+      color: 'secondary.contrastText',
+    },
+  };
+
   if (variant === 'icon') {
     return (
       <IconButton
@@ -38,7 +70,11 @@ const Button = (
         color={buttonColor}
         disabled={disabled}
         size="large"
-        sx={{ ...sx }}
+        sx={{
+          ...sx,
+          '&.MuiIconButton-colorPrimary': iconPrimary,
+          '&.MuiIconButton-colorSecondary': iconSecondary,
+        }}
         {...props}
       >
         {children}
@@ -48,14 +84,7 @@ const Button = (
 
   if (variant === 'fab') {
     return (
-      <Fab
-        ref={ref}
-        color={buttonColor}
-        disabled={disabled}
-        size="large"
-        sx={{ ...sx }}
-        {...props}
-      >
+      <Fab ref={ref} color={buttonColor} disabled={disabled} size="large" sx={{ ...sx }} {...props}>
         {children}
       </Fab>
     );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -63,6 +63,22 @@ const Button = (
     },
   };
 
+  const iconDanger = {
+    '&::before': {
+      backgroundColor: 'error.dark',
+    },
+    '&:hover': {
+      backgroundColor: 'errorStates.hover',
+    },
+    '&:active': {
+      backgroundColor: 'errorStates.activeContained',
+    },
+    '&.Mui-disabled': {
+      backgroundColor: 'errorStates.disabledBg',
+      color: 'error.contrastText',
+    },
+  };
+
   if (variant === 'icon') {
     return (
       <IconButton
@@ -74,6 +90,7 @@ const Button = (
           ...sx,
           '&.MuiIconButton-colorPrimary': iconPrimary,
           '&.MuiIconButton-colorSecondary': iconSecondary,
+          '&.MuiIconButton-colorError': iconDanger,
         }}
         {...props}
       >

--- a/stories/Inputs/Button.stories.tsx
+++ b/stories/Inputs/Button.stories.tsx
@@ -98,6 +98,13 @@ Icon.args = {
   children: <Bin />,
 };
 
+export const IconPrimary = Template.bind({});
+IconPrimary.args = {
+  variant: 'icon',
+  color: 'primary',
+  children: <Bin />,
+};
+
 export const Fab = Template.bind({});
 Fab.args = {
   variant: 'fab',


### PR DESCRIPTION
## Background

The hover color for icon buttons was only 4 % opacity color. In design system figma there is a hover color defined that uses 10% opacity. Let's use that for the icon hover states.

## 🛠 Fixes

- Icon button hover color.
