### PR TITLE
Fix build type error related to Popper component type exports

### DIFF
--- a/src/components/Popper.tsx
+++ b/src/components/Popper.tsx
@@ -1,7 +1,7 @@
 import { Popper as MuiPopper, PopperProps as MuiPopperProps } from '@mui/material';
 import { forwardRef, Ref } from 'react';
 
-export type PopperProps = MuiPopperProps;
+export interface PopperProps extends MuiPopperProps {}
 
 const Popper = (props: PopperProps, ref: Ref<HTMLDivElement>): JSX.Element => {
   return <MuiPopper ref={ref} {...props} />;


### PR DESCRIPTION
## Background

Typescript `type` doesn't allow declaration merging but `interface` does. [Some more info on the topic](https://blog.logrocket.com/types-vs-interfaces-in-typescript/#:~:text=any%20other%20type.-,Declaration%20merging,-One%20thing%20that%E2%80%99s)

Because we import the type from MUI we need to merge that with the now exported interface or we'll miss out on the properties that MUI defines. This produces an error only in the build time because our `tsconfig.release.json` has `declaration: true`

## 🛠 Fixes

- Fix Popper component type exports