### PR TITLE
Export datagrid api hooks from DataGrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -8,6 +8,8 @@ import {
 } from '@mui/x-data-grid';
 import { forwardRef, Ref } from 'react';
 
+export { useGridApiRef, useGridApiContext } from '@mui/x-data-grid';
+
 export interface GridColumnHeaderParams extends MuiGridColumnHeaderParams {}
 export interface GridColumns extends MuiGridColumns {}
 export interface GridRowsProp extends MuiGridRowsProp {}


### PR DESCRIPTION
## Background

Why are these changes needed?
Those hooks are necessary to create a custom pagination for the DataGrid

## 💡 Feature 1

- export datagrid api hooks from DataGrid
