### PR TITLE
Re-export grid sorting model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.0.32",
+      "version": "1.0.33",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -5,6 +5,8 @@ import {
   GridRowsProp as MuiGridRowsProp,
   GridSelectionModel as MuiGridSelectionModel,
   GridColumnHeaderParams as MuiGridColumnHeaderParams,
+  GridCallbackDetails as MuiGridCallbackDetails,
+  GridSortModel as MuiGridSortModel,
 } from '@mui/x-data-grid';
 import { forwardRef, Ref } from 'react';
 
@@ -14,6 +16,8 @@ export interface GridColumnHeaderParams extends MuiGridColumnHeaderParams {}
 export interface GridColumns extends MuiGridColumns {}
 export interface GridRowsProp extends MuiGridRowsProp {}
 export interface GridSelectionModel extends MuiGridSelectionModel {}
+export interface GridCallbackDetails extends MuiGridCallbackDetails {}
+export interface GridSortModel extends MuiGridSortModel {}
 
 export interface DataGridProps extends MuiDataGridProps {
   columns: GridColumns;


### PR DESCRIPTION
## Background

**Why are these changes needed?**
Some sort-related types are not being re-exported from mui.

## 💡 Re-export missing Grid types
- export `GridSortModel` and `GridSortModel` types
