### PR TITLE
Move tooltip styling from componentProps to sx for better extensibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -18,11 +18,11 @@ export interface TooltipProps extends MuiTooltipProps {
     | 'top';
   title: NonNullable<React.ReactNode>;
   'data-testid'?: string;
-  ref?: Ref<HTMLDivElement>
+  ref?: Ref<HTMLDivElement>;
 }
 
 const Tooltip = (
-  { arrow = false, placement = 'bottom', children, title, ...props }: TooltipProps,
+  { arrow = false, placement = 'bottom', children, title, sx = {}, ...props }: TooltipProps,
   ref: Ref<HTMLDivElement>
 ): JSX.Element => {
   return (
@@ -30,9 +30,14 @@ const Tooltip = (
       title={title}
       arrow={arrow}
       placement={placement}
-      componentsProps={{
-        tooltip: { sx: { fontSize: '12px', backgroundColor: 'grey.400', borderRadius: '3px' } },
-        arrow: { sx: { fontSize: '8px', color: 'grey.400' } },
+      sx={{
+        '& .MuiTooltip-tooltip': {
+          fontSize: '12px',
+          backgroundColor: 'grey.400',
+          borderRadius: '3px',
+        },
+        '& .MuiTooltip-arrow': { fontSize: '8px', color: 'grey.400' },
+        ...sx,
       }}
       ref={ref}
       {...props}


### PR DESCRIPTION
## Background

Make it easier to add custom styling for tooltips

## 🛠 Fixes

- Move Tooltip styling from componentProps to sx for better extensibility
