### PR TITLE
Fix styling and move it to slotProps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.0.34",
+      "version": "1.0.35",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -30,14 +30,12 @@ const Tooltip = (
       title={title}
       arrow={arrow}
       placement={placement}
-      sx={{
-        '& .MuiTooltip-tooltip': {
-          fontSize: '12px',
-          backgroundColor: 'grey.400',
-          borderRadius: '3px',
+      slotProps={{
+        tooltip: { sx: { fontSize: '12px', backgroundColor: 'grey.400', borderRadius: '3px' } },
+        arrow: { sx: { fontSize: '8px', color: 'grey.400' } },
+        popper: {
+          sx: { ...sx },
         },
-        '& .MuiTooltip-arrow': { fontSize: '8px', color: 'grey.400' },
-        ...sx,
       }}
       ref={ref}
       {...props}

--- a/stories/DataDisplay/Tooltip.stories.tsx
+++ b/stories/DataDisplay/Tooltip.stories.tsx
@@ -53,3 +53,21 @@ ArrowRight.args = {
   placement: 'left',
   arrow: true,
 };
+
+export const Styling = Template.bind({});
+Styling.args = {
+  title: 'My Tooltip',
+  arrow: true,
+  sx: {
+    '& .MuiTooltip-tooltip': {
+      fontSize: '24px',
+      backgroundColor: '#045B56',
+      borderRadius: '12px',
+      color: '#FCF8F3',
+    },
+    '& .MuiTooltip-arrow': {
+      fontSize: '16px',
+      color: '#045B56',
+    },
+  },
+};


### PR DESCRIPTION
## Background

Styling with sx was not being applied at all. So this makes styling easier to do and work properly, while having default values and being able to change just one property without overriding everything.

## 🛠 Fixes

- Move styling from to slotProps and add sx prop to popper
