### PR TITLE
Make the Dialog accepting array of children

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -10,7 +10,7 @@ import Button from './Button';
 import { Close } from '../icons';
 
 export interface DialogProps extends MuiDialogProps {
-  children: JSX.Element | string;
+  children: JSX.Element | JSX.Element[] | string;
   dialogActions?: JSX.Element | JSX.Element[];
   dialogTitle: JSX.Element | string;
   fullScreen?: boolean;


### PR DESCRIPTION
## Background

Why are these changes needed?
Sometimes we need to pass more children components to this dialog than just one. This PR introduces that possibility so there is no need to pass a react element (<></>) as a children parent anymore

## 💡 Feature 1

- Make the Dialog accepting array of children `JSX.Element[]` as well
