### PR TITLE
Fix LicenseInfo export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export { default as Grow } from './components/Grow';
 export { default as InputAdornment } from './components/InputAdornment';
 export { default as InputLabel } from './components/InputLabel';
 export { default as LanguageSelector } from './components/LanguageSelector';
-export { default as LicenseInfo } from '@mui/x-license-pro';
+export { LicenseInfo as LicenseInfo } from '@mui/x-license-pro';
 export { default as Link } from './components/Link';
 export { default as List } from '@mui/material/List';
 export { default as ListItem } from '@mui/material/ListItem';


### PR DESCRIPTION
## Background

Improper export of LicenseInfo from @mui/x-license-pro

## 🛠 Fixes

- Export LicenseInfo correctly
