### PR TITLE
Version 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.0.36",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.0.36",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.0.35",
+      "version": "1.0.36",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.0.36",
+  "version": "1.1.0",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export { default as Grow } from './components/Grow';
 export { default as InputAdornment } from './components/InputAdornment';
 export { default as InputLabel } from './components/InputLabel';
 export { default as LanguageSelector } from './components/LanguageSelector';
-export { default as LicenseInfo } from '@mui/x-license-pro';
+export { LicenseInfo as LicenseInfo } from '@mui/x-license-pro';
 export { default as Link } from './components/Link';
 export { default as List } from '@mui/material/List';
 export { default as ListItem } from '@mui/material/ListItem';


### PR DESCRIPTION
## Background

LicenseInfo from @mui/x-license-pro was improperly exported

## 🛠 Fixes

- Instead of default export of @mui/x-license-pro export named export `LicenseInfo`