### PR TITLE
Add QrCode icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "engines": {
     "node": "^16",
     "npm": "^8"

--- a/src/icons/QrCode.tsx
+++ b/src/icons/QrCode.tsx
@@ -1,38 +1,36 @@
 import { createElement } from 'react';
 import SvgIcon from '@mui/material/SvgIcon';
+
 const QrCode = (props: any) =>
   createElement(
     SvgIcon,
     props,
+    <defs>
+      <style>{'.qr_code_svg{fill:none;stroke:currentColor;stroke-width:3px}'}</style>
+    </defs>,
     <mask id="qr_code_svg__a" fill="#fff">
       <path d="M0 1a1 1 0 0 1 1-1h9.2a1 1 0 0 1 1 1v9.2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V1Z" />
     </mask>,
     <path
       d="M0 1a1 1 0 0 1 1-1h9.2a1 1 0 0 1 1 1v9.2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V1Z"
-      stroke="currentColor"
-      strokeWidth={3}
+      className='qr_code_svg'
       mask="url(#qr_code_svg__a)"
-      fill="none"
     />,
     <mask id="qr_code_svg__b" fill="#fff">
       <path d="M0 13.8a1 1 0 0 1 1-1h9.2a1 1 0 0 1 1 1V23a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-9.2Z" />
     </mask>,
     <path
       d="M0 13.8a1 1 0 0 1 1-1h9.2a1 1 0 0 1 1 1V23a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-9.2Z"
-      stroke="currentColor"
-      strokeWidth={3}
+      className='qr_code_svg'
       mask="url(#qr_code_svg__b)"
-      fill="none"
     />,
     <mask id="qr_code_svg__c" fill="#fff">
       <path d="M12.8 1a1 1 0 0 1 1-1H23a1 1 0 0 1 1 1v9.2a1 1 0 0 1-1 1h-9.2a1 1 0 0 1-1-1V1Z" />
     </mask>,
     <path
       d="M12.8 1a1 1 0 0 1 1-1H23a1 1 0 0 1 1 1v9.2a1 1 0 0 1-1 1h-9.2a1 1 0 0 1-1-1V1Z"
-      stroke="currentColor"
-      strokeWidth={3}
+      className='qr_code_svg'
       mask="url(#qr_code_svg__c)"
-      fill="none"
     />,
     <path
       d="M13.3 13.8a.5.5 0 0 1 .5-.5h3.072a.5.5 0 0 1 .5.5v3.072a.5.5 0 0 1-.5.5H13.8a.5.5 0 0 1-.5-.5V13.8ZM19.428 13.8a.5.5 0 0 1 .5-.5H23a.5.5 0 0 1 .5.5v3.072a.5.5 0 0 1-.5.5h-3.072a.5.5 0 0 1-.5-.5V13.8ZM19.428 19.928a.5.5 0 0 1 .5-.5H23a.5.5 0 0 1 .5.5V23a.5.5 0 0 1-.5.5h-3.072a.5.5 0 0 1-.5-.5v-3.072ZM13.3 19.928a.5.5 0 0 1 .5-.5h3.072a.5.5 0 0 1 .5.5V23a.5.5 0 0 1-.5.5H13.8a.5.5 0 0 1-.5-.5v-3.072Z"

--- a/src/icons/QrCode.tsx
+++ b/src/icons/QrCode.tsx
@@ -1,0 +1,43 @@
+import { createElement } from 'react';
+import SvgIcon from '@mui/material/SvgIcon';
+const QrCode = (props: any) =>
+  createElement(
+    SvgIcon,
+    props,
+    <mask id="qr_code_svg__a" fill="#fff">
+      <path d="M0 1a1 1 0 0 1 1-1h9.2a1 1 0 0 1 1 1v9.2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V1Z" />
+    </mask>,
+    <path
+      d="M0 1a1 1 0 0 1 1-1h9.2a1 1 0 0 1 1 1v9.2a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V1Z"
+      stroke="currentColor"
+      strokeWidth={3}
+      mask="url(#qr_code_svg__a)"
+      fill="none"
+    />,
+    <mask id="qr_code_svg__b" fill="#fff">
+      <path d="M0 13.8a1 1 0 0 1 1-1h9.2a1 1 0 0 1 1 1V23a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-9.2Z" />
+    </mask>,
+    <path
+      d="M0 13.8a1 1 0 0 1 1-1h9.2a1 1 0 0 1 1 1V23a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1v-9.2Z"
+      stroke="currentColor"
+      strokeWidth={3}
+      mask="url(#qr_code_svg__b)"
+      fill="none"
+    />,
+    <mask id="qr_code_svg__c" fill="#fff">
+      <path d="M12.8 1a1 1 0 0 1 1-1H23a1 1 0 0 1 1 1v9.2a1 1 0 0 1-1 1h-9.2a1 1 0 0 1-1-1V1Z" />
+    </mask>,
+    <path
+      d="M12.8 1a1 1 0 0 1 1-1H23a1 1 0 0 1 1 1v9.2a1 1 0 0 1-1 1h-9.2a1 1 0 0 1-1-1V1Z"
+      stroke="currentColor"
+      strokeWidth={3}
+      mask="url(#qr_code_svg__c)"
+      fill="none"
+    />,
+    <path
+      d="M13.3 13.8a.5.5 0 0 1 .5-.5h3.072a.5.5 0 0 1 .5.5v3.072a.5.5 0 0 1-.5.5H13.8a.5.5 0 0 1-.5-.5V13.8ZM19.428 13.8a.5.5 0 0 1 .5-.5H23a.5.5 0 0 1 .5.5v3.072a.5.5 0 0 1-.5.5h-3.072a.5.5 0 0 1-.5-.5V13.8ZM19.428 19.928a.5.5 0 0 1 .5-.5H23a.5.5 0 0 1 .5.5V23a.5.5 0 0 1-.5.5h-3.072a.5.5 0 0 1-.5-.5v-3.072ZM13.3 19.928a.5.5 0 0 1 .5-.5h3.072a.5.5 0 0 1 .5.5V23a.5.5 0 0 1-.5.5H13.8a.5.5 0 0 1-.5-.5v-3.072Z"
+      stroke="currentColor"
+      fill="none"
+    />
+  );
+export default QrCode;

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -104,3 +104,4 @@ export { default as LightBulb } from './LightBulb';
 export { default as NotAllowed } from './NotAllowed';
 export { default as Trigger } from './Trigger';
 export { default as Phone } from './Phone';
+export { default as QrCode } from './QrCode';

--- a/stories/DataDisplay/Icons.stories.tsx
+++ b/stories/DataDisplay/Icons.stories.tsx
@@ -165,6 +165,7 @@ const iconsList = [
   { name: 'NotAllowed', component: i.NotAllowed },
   { name: 'Trigger', component: i.Trigger },
   { name: 'Phone', component: i.Phone },
+  { name: 'QrCode', component: i.QrCode },
 ];
 
 const Template: Story<SvgIconProps> = (args) => {


### PR DESCRIPTION
## Background

Why are these changes needed?
Design system was missing QrIcon, which is already in the figma icon set

![Screenshot 2022-12-20 at 12 40 25](https://user-images.githubusercontent.com/26175185/208658625-23dfe425-1ca4-436c-9fda-7dc8a1c68cf2.png)

## 💡 Feature 1

- add QrIcon