### PR TITLE
Remove failing Github package release

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,4 +1,4 @@
-# This workflow creates a Tag, GitHub release, publishes the built package to NPM and to Github packages
+# This workflow creates a Tag, GitHub release, publishes the built package to NPM
 
 name: Publish Lyyti Design System
 
@@ -62,12 +62,3 @@ jobs:
         run: npm publish ./dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          registry-url: https://npm.pkg.github.com
-          scope: '@lyytioy'
-      - name: Publish Github
-        run: npm publish ./dist
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Background

We added a step for building a Github package [back in May](https://github.com/lyytioy/lyyti-design-system/pull/59) and it has never after that worked properly. Fixing it seems to involve a lot of debugging of setup-node and potentially some changes to the action. At this point it seems not worth the time investment so we're also fine with removing the Github package and relying totally on the npm package

## 🛠 Fixes

- Remove failing Github package release