### PR TITLE
Adjust GitHub workflow triggers

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -10,6 +10,8 @@ on:
       - 'stories/**'
       - 'public/**'
       - 'typings/**'
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   compare-versions:

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -12,6 +12,8 @@ on:
       - 'src/**'
       - 'public/**'
       - 'typings/**'
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
     inputs:
       accept:
@@ -23,7 +25,7 @@ on:
 
 jobs:
   create-release:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event.inputs.accept == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +47,7 @@ jobs:
           TAG: v${{ steps.package-version.outputs.current-version }}
 
   publish-package:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event.inputs.accept == true
     needs: create-release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Background

When fixing v1.1.3 the package didn't get published because the changed files didn't match the specified paths. And manual triggering wasn't possible due to the if checks https://github.com/lyytioy/lyyti-design-system/actions/runs/3787681245

## 🛠 Fixes

- Allow manual workflow dispatches to pass if checks, trigger workflow on package.json changes
- Trigger version checking on package.json changes
