### PR TITLE
Fix manual publish action by 

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   create-release:
-    if: github.event.pull_request.merged == true || inputs.accept == true
+    if: github.event.pull_request.merged == true || github.event.inputs.accept == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   create-release:
-    if: github.event.pull_request.merged == true || github.event.inputs.accept
+    if: github.event.pull_request.merged == true || inputs.accept == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -47,7 +47,7 @@ jobs:
           TAG: v${{ steps.package-version.outputs.current-version }}
 
   publish-package:
-    if: github.event.pull_request.merged == true || inputs.accept == true
+    if: github.event.pull_request.merged == true || github.event.inputs.accept == 'true'
     needs: create-release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   create-release:
-    if: github.event.pull_request.merged == true || github.event.inputs.accept == true
+    if: github.event.pull_request.merged == true || github.event.inputs.accept
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
           TAG: v${{ steps.package-version.outputs.current-version }}
 
   publish-package:
-    if: github.event.pull_request.merged == true || github.event.inputs.accept == true
+    if: github.event.pull_request.merged == true || inputs.accept == true
     needs: create-release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Background

The previous syntax for inputs value checking in this manually dispatched publish action didn't result in wanted behaviour as both steps of the workflow were skipped https://github.com/lyytioy/lyyti-design-system/actions/runs/3796940315

The inputs values from github context seem to actually be string type which fixes the comparison as seen here
https://github.com/lyytioy/lyyti-design-system/actions/runs/3796987754/jobs/6457555791

## 🛠 Fixes

- Treat manually dispatched publish action inputs values as strings