### PR TITLE
Add ref forwarding to Grid and Typography components

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -1,8 +1,9 @@
 import { Grid as MuiGrid, GridProps as MuiGridProps } from '@mui/material';
+import { forwardRef, Ref } from 'react';
 
 export type GridProps = MuiGridProps;
 
-const Grid = (props: GridProps): JSX.Element => {
-  return <MuiGrid {...props} />;
+const Grid = (props: GridProps, ref: Ref<HTMLDivElement>): JSX.Element => {
+  return <MuiGrid ref={ref} {...props} />;
 };
-export default Grid;
+export default forwardRef(Grid);

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -1,5 +1,5 @@
 import { Typography as MuiTypography, TypographyProps as MuiTypographyProps } from '@mui/material';
-import { ElementType } from 'react';
+import { ElementType, forwardRef, Ref } from 'react';
 
 export type VariantTypes =
   | 'h1'
@@ -21,8 +21,11 @@ export interface TypographyProps
   'data-testid'?: string;
 }
 
-const Typography = ({ variant = 'body1', ...props }: TypographyProps): JSX.Element => {
-  return <MuiTypography variant={variant} {...props} />;
+const Typography = (
+  { variant = 'body1', ...props }: TypographyProps,
+  ref: Ref<HTMLElement>
+): JSX.Element => {
+  return <MuiTypography variant={variant} ref={ref} {...props} />;
 };
 
-export default Typography;
+export default forwardRef(Typography);


### PR DESCRIPTION
## Background

Most of our components (non-internal) already forward refs but it seems like Grid and Typography are missing that. This was noticed in one of our apps using the design system where console errors popped up about it

Typography component is used for so many different purposes that typing the ref gets a bit complex as you would need to support `p`, headings, inline text elements, list elements and potentially other React components from i18n libraries that I left it just at HTMLElement to allow multiple scenarios. I couldn't find any types for it in [mui/material](https://github.com/mui/material-ui/tree/master/packages/mui-material/src/Typography) either so followed their tinking with this

## 🛠 Fixes

- Forward ref in Grid component
- Forward ref in Typography component
