### PR TITLE
add new typography variant and convert body2 to use previous styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": "^18",
     "npm": "^8"

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -12,6 +12,7 @@ export type VariantTypes =
   | 'body1'
   | 'body2'
   | 'caption'
+  | 'navigationLink'
   | 'inherit';
 
 export interface TypographyProps

--- a/src/themes/theme.ts
+++ b/src/themes/theme.ts
@@ -1,5 +1,4 @@
-import { createTheme } from '@mui/material/styles';
-import { Theme } from '@mui/material/styles';
+import { createTheme, Theme } from '@mui/material/styles';
 
 const baseFontStack = [
   '-apple-system',
@@ -72,6 +71,24 @@ declare module '@mui/material/styles/createPalette' {
     sunset: ColorRangeOptions;
     sun: ColorRangeOptions;
     sand: ColorRangeOptions;
+  }
+}
+
+declare module '@mui/material/styles' {
+  interface TypographyVariants {
+    navigationLink: React.CSSProperties;
+  }
+
+  // allow configuration using `createTheme`
+  interface TypographyVariantsOptions {
+    navigationLink?: React.CSSProperties;
+  }
+}
+
+// Update the Typography's variant prop options
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides {
+    navigationLink: true;
   }
 }
 
@@ -268,11 +285,8 @@ export default createTheme({
       letterSpacing: '0em',
     },
     body2: {
-      fontFamily: objektivMk1FontFamily,
-      fontSize: '0.75rem',
-      letterSpacing: '0.8px',
-      textTransform: 'uppercase',
-      color: 'text.primary',
+      fontSize: '1rem',
+      letterSpacing: '0em',
     },
     button: {
       fontFamily: objektivMk1FontFamily,
@@ -288,6 +302,11 @@ export default createTheme({
       letterSpacing: '0em',
     },
     overline: {},
+    navigationLink: {
+      fontFamily: objektivMk1FontFamily,
+      fontSize: '0.75rem',
+      letterSpacing: '0.8px',
+    },
   },
   components: {
     MuiCheckbox: {

--- a/stories/DataDisplay/Typography.stories.tsx
+++ b/stories/DataDisplay/Typography.stories.tsx
@@ -84,8 +84,8 @@ PStyledAsH1.args = {
   color: 'primary',
 };
 
-export const Body2 = Template.bind({});
-Body2.args = {
-  variant: 'body2',
+export const NavigationLink = Template.bind({});
+NavigationLink.args = {
+  variant: 'navigationLink',
   children: 'Back to previous page',
 };


### PR DESCRIPTION
## Background

Add new Typography variant to be used in Portal app in Back to navigation links. Convert changes done to Typography variant="body2".

## ⚠️ BREAKING CHANGES ⚠️

- Typography variant="body2" was converted back to using same styles as variant="body1" because it is used under the hood in multiple MUI components.
