### PR TITLE
NG-2004 update tab styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "engines": {
     "node": "^18",
     "npm": "^8"

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -1,7 +1,7 @@
 import { Tab as MuiTab, TabProps as MuiTabProps } from '@mui/material';
 import { forwardRef, Ref } from 'react';
 
-export type TabProps = MuiTabProps;
+export type TabProps = Omit<MuiTabProps, 'textColor' | 'indicatorColor'>;
 
 const Tab = ({ sx = {}, ...props }: TabProps, ref: Ref<HTMLDivElement>): JSX.Element => {
   return (
@@ -9,7 +9,6 @@ const Tab = ({ sx = {}, ...props }: TabProps, ref: Ref<HTMLDivElement>): JSX.Ele
       ref={ref}
       sx={{
         fontSize: '16px',
-        '& .MuiTab.Mui-disabled': { color: 'text.disabled' },
         '&.MuiTab-wrapped': { fontSize: '13px' },
         ...sx,
       }}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,9 +1,32 @@
 import { Tabs as MuiTabs, TabsProps as MuiTabsProps } from '@mui/material';
 
-export type TabsProps = MuiTabsProps;
+export interface TabsProps extends Omit<MuiTabsProps, 'textColor' | 'indicatorColor'> {
+  color?: 'sky' | 'secondary';
+}
 
-const Tabs = (props: TabsProps): JSX.Element => {
-  return <MuiTabs {...props} />;
+const Tabs = ({ color = 'sky', sx = {}, ...props }: TabsProps): JSX.Element => {
+  const tabColor = color === 'sky' ? 'sky.500' : 'secondary.main';
+
+  return (
+    <MuiTabs
+      sx={{
+        '& .MuiTab-root': {
+          color: tabColor,
+          '&.Mui-disabled': {
+            color: 'text.disabled',
+          },
+          '&.Mui-selected': {
+            color: tabColor,
+            fontWeight: 'bold',
+          },
+        },
+        '& .MuiTabs-indicator': {
+          bgcolor: tabColor,
+        },
+      }}
+      {...props}
+    />
+  );
 };
 
 export default Tabs;

--- a/stories/Navigation/Tabs.stories.tsx
+++ b/stories/Navigation/Tabs.stories.tsx
@@ -18,8 +18,6 @@ const Template: Story<TabsProps> = (args) => <Tabs {...args} />;
 
 export const Horizontal = Template.bind({});
 Horizontal.args = {
-  indicatorColor: 'primary',
-  textColor: 'primary',
   value: 0,
   children: [
     <Tab key={1} label="Active" />,
@@ -32,8 +30,7 @@ Horizontal.args = {
 export const Vertical = Template.bind({});
 Vertical.args = {
   orientation: 'vertical',
-  indicatorColor: 'secondary',
-  textColor: 'secondary',
+  color: 'secondary',
   value: 1,
   children: [
     <Tab key={1} label="Default" />,


### PR DESCRIPTION
## Background

Improve the accessibility of Tab component.

## 🛠 Fixes

- Primary color is changed to sky to follow the color of headings.
- Unselected tab is changed to use sky.500 color
- Selected tab fontWeight is bold
- Bump version to 1.2.2

## ⚠️ BREAKING CHANGES ⚠️

- Tabs component has now prop color instead of separate textColor and indicatorColor props.
