### PR TITLE
Allow styles to be given with sx prop

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -23,6 +23,7 @@ const Tabs = ({ color = 'sky', sx = {}, ...props }: TabsProps): JSX.Element => {
         '& .MuiTabs-indicator': {
           bgcolor: tabColor,
         },
+        ...sx,
       }}
       {...props}
     />


### PR DESCRIPTION
## Background

Tabs component was missing the possibility give styles with sx prop.

