### PR TITLE
Remove 'color' prop from Switch component

### DIFF
--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -20,6 +20,18 @@ const Switch = ({ sx = {}, ...props }: SwitchProps, ref: Ref<HTMLButtonElement>)
             '&:hover': {
               backgroundColor: 'primaryStates.hover',
             },
+            '&.MuiSwitch-colorSecondary': {
+              color: 'secondary.main',
+              '&:hover': {
+                backgroundColor: 'secondaryStates.hover',
+              },
+            },
+            '&.MuiSwitch-colorError': {
+              color: 'error.main',
+              '&:hover': {
+                backgroundColor: 'errorStates.hover',
+              },
+            },
           },
           '&.Mui-disabled': {
             color: 'grey.100',

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,7 +1,7 @@
 import { Switch as MuiSwitch, SwitchProps as MuiSwitchProps } from '@mui/material';
 import { forwardRef, Ref } from 'react';
 
-export type SwitchProps = MuiSwitchProps;
+export type SwitchProps = Omit<MuiSwitchProps, 'color'>;
 
 const Switch = ({ sx = {}, ...props }: SwitchProps, ref: Ref<HTMLButtonElement>): JSX.Element => {
   return (
@@ -19,12 +19,6 @@ const Switch = ({ sx = {}, ...props }: SwitchProps, ref: Ref<HTMLButtonElement>)
             color: 'primary.main',
             '&:hover': {
               backgroundColor: 'primaryStates.hover',
-            },
-            '&.MuiSwitch-colorSecondary': {
-              color: 'secondary.main',
-              '&:hover': {
-                backgroundColor: 'secondaryStates.hover',
-              },
             },
           },
           '&.Mui-disabled': {

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -26,12 +26,6 @@ const Switch = ({ sx = {}, ...props }: SwitchProps, ref: Ref<HTMLButtonElement>)
                 backgroundColor: 'secondaryStates.hover',
               },
             },
-            '&.MuiSwitch-colorError': {
-              color: 'error.main',
-              '&:hover': {
-                backgroundColor: 'errorStates.hover',
-              },
-            },
           },
           '&.Mui-disabled': {
             color: 'grey.100',

--- a/stories/Inputs/Switch.stories.tsx
+++ b/stories/Inputs/Switch.stories.tsx
@@ -35,3 +35,15 @@ Label.args = {
   control: <Switch />,
   label: 'Label',
 };
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  checked: true,
+  color: 'secondary',
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  checked: true,
+  color: 'error',
+};

--- a/stories/Inputs/Switch.stories.tsx
+++ b/stories/Inputs/Switch.stories.tsx
@@ -35,9 +35,3 @@ Label.args = {
   control: <Switch />,
   label: 'Label',
 };
-
-export const Secondary = Template.bind({});
-Secondary.args = {
-  checked: true,
-  color: 'secondary',
-};

--- a/stories/Inputs/Switch.stories.tsx
+++ b/stories/Inputs/Switch.stories.tsx
@@ -41,9 +41,3 @@ Secondary.args = {
   checked: true,
   color: 'secondary',
 };
-
-export const Error = Template.bind({});
-Error.args = {
-  checked: true,
-  color: 'error',
-};


### PR DESCRIPTION
## Background

Why are these changes needed?
Current version of Switch component allows passing color variant which is not valid in our design system - only primary color

## 💡 Feature 1

- remove `color` prop from Switch component
