### PR TITLE
Fix build error with InputLabel and add workflow step to test package build before release

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -32,3 +32,15 @@ jobs:
         run: |
           echo "You need to have a different package.json version than the one in main"
           exit 1
+
+  test-build:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.13.0
+      - name: Install dependencies
+        run: npm ci
+      - name: Build package
+        run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "engines": {
     "node": "^18",
     "npm": "^8"

--- a/src/components/InputLabel.tsx
+++ b/src/components/InputLabel.tsx
@@ -1,7 +1,7 @@
 import { InputLabel as MuiInputLabel, InputLabelProps as MuiInputLabelProps } from '@mui/material';
 import { forwardRef, Ref } from 'react';
 
-export type InputLabelProps = MuiInputLabelProps;
+export interface InputLabelProps extends MuiInputLabelProps {}
 
 const InputLabel = (
   { sx = {}, ...props }: InputLabelProps,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,19 @@
 {
   "compilerOptions": {
+    "module": "esnext",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "noEmit": true
   },
   "include": ["next-env.d.ts", "index.d.ts", "src", "typings", "stories"],
   "exclude": ["fonts"]

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -6,17 +6,17 @@
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
+    "removeComments": true,
+    "allowSyntheticDefaultImports": true,
     "outDir": "dist",
     "declaration": true,
-    "declarationDir": "dist",
-    "removeComments": true
+    "declarationDir": "dist"
   },
   "include": ["index.d.ts", "src", "typings"],
   "exclude": ["fonts", "stories"]


### PR DESCRIPTION
## Background

Build currently fails with error `error TS4082: Default export of the module has or is using private name 'FormLabelOwnProps'.` in `src/components/InputLabel.tsx(19,1)`

https://github.com/lyytioy/lyyti-design-system/actions/runs/4101715094/jobs/7074434159

## 🛠 Fixes

- Fixes build error with InputLabel types
- Run package build on PRs to main to find build errors before release