### PR TITLE
add icons and subtitle to dropdownmenu

### DIFF
--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -1,19 +1,24 @@
 /* eslint-disable react/prop-types */
+import { ListItemIcon, ListItemText } from '@mui/material';
 import { useState, MouseEvent as ReactMouseEvent } from 'react';
 import Button, { ButtonProps } from './Button';
 import Menu from './Menu';
-import MenuItem from './MenuItem';
+import MenuItem, { MenuItemProps } from './MenuItem';
+import { TypographyProps } from './Typography';
 
 export interface DropdownProps {
   title: string;
   onSelect: (clickedItem: number) => void;
-  items: Array<{ id: number; title: string }>;
+  items: Array<{ id: number; title: string; icon?: any }>;
   buttonProps: ButtonProps;
+  subtitle?: string;
+  menuItemProps?: MenuItemProps;
+  textProps?: TypographyProps;
 }
 
 const toHMTLAttribute = (item: string) => {
   return item.replaceAll(' ', '-').toLowerCase();
-}
+};
 
 const DropdownMenu = (props: DropdownProps): JSX.Element => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -43,9 +48,22 @@ const DropdownMenu = (props: DropdownProps): JSX.Element => {
         {props.title}
       </Button>
       <Menu id="menu-list-grow" anchorEl={anchorEl} open={open} onClose={handleClose}>
+        {props.subtitle && (
+          <ListItemText primaryTypographyProps={{ ...props.textProps }} sx={{ pl: 1.5, pb: 0.5 }}>
+            {props.subtitle}
+          </ListItemText>
+        )}
         {props.items.map((item) => (
-          <MenuItem key={item.id} onClick={(event) => selectItem(event, item.id)} data-testid={toHMTLAttribute(item.title)}>
-            {item.title}
+          <MenuItem
+            key={item.id}
+            onClick={(event) => selectItem(event, item.id)}
+            data-testid={toHMTLAttribute(item.title)}
+            {...props.menuItemProps}
+          >
+            {item.icon && <ListItemIcon>{item.icon}</ListItemIcon>}
+            <ListItemText primaryTypographyProps={{ ...props.textProps }}>
+              {item.title}
+            </ListItemText>
           </MenuItem>
         ))}
       </Menu>

--- a/stories/Navigation/DropdownMenu.stories.tsx
+++ b/stories/Navigation/DropdownMenu.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
 import DropdownMenu, { DropdownProps } from '../../src/components/DropdownMenu';
+import { Calendar, ChevronDown, Radio, Rectangle } from '../../src/icons';
 
 export default {
   title: 'Components/Navigation/Menu',
@@ -12,11 +13,37 @@ const menuItems = [
   { id: 3, title: 'Menu item 3' },
 ];
 
+const menuItems2 = [
+  { id: 1, title: 'Menu item 1', icon: <Calendar fontSize="small" /> },
+  { id: 2, title: 'Menu item 2', icon: <Rectangle fontSize="small" /> },
+  { id: 3, title: 'Menu item 2', icon: <Radio fontSize="small" /> },
+];
+
 const Template: Story<DropdownProps> = (args) => <DropdownMenu {...args} />;
 
 export const Dropdown = Template.bind({});
 Dropdown.args = {
   title: 'Open menu',
   items: menuItems,
-  buttonProps: { children: '', variant: 'outlined', color: 'primary', chunky: false },
+  buttonProps: {
+    children: '',
+    variant: 'outlined',
+    color: 'primary',
+    chunky: false,
+  },
+};
+
+export const DropdownIcons = Template.bind({});
+DropdownIcons.args = {
+  title: 'Open menu',
+  items: menuItems2,
+  subtitle: 'Subtitle',
+  buttonProps: {
+    children: '',
+    color: 'primary',
+    chunky: true,
+    endIcon: <ChevronDown />,
+  },
+  menuItemProps: { sx: { py: 1.5, pl: 3 } },
+  textProps: { color: 'primary' },
 };


### PR DESCRIPTION
## Background

Adds the ability to put icons and a subtitle to the dropdown menu for further customization in production

## 💡 Dropdown menu

- add icons to items to add as starticons
- menuItemsProps to customise items in dropdown
- subtitle prop to add a subtitle
- textProps to customise text in menu


## ⚠️ BREAKING CHANGES ⚠️

- No breaking changes 😄 

