### PR TITLE
Add optional description prop to Select option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.3.9",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.3.9",
+  "version": "1.4.0",
   "engines": {
     "node": "^18",
     "npm": "^8"

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -42,6 +42,7 @@ export interface AutocompleteProps<T = OptionsType>
   color?: ColorTypes;
   error?: boolean;
   helperText?: string;
+  optionDivider?: boolean;
   'data-testid'?: string;
   ref?: Ref<HTMLDivElement>;
 }
@@ -60,6 +61,7 @@ const Autocomplete = (
     disabled = false,
     error,
     helperText,
+    optionDivider,
     'data-testid': testid,
     sx = {},
     ...props
@@ -118,10 +120,17 @@ const Autocomplete = (
             {...props}
             sx={{
               ...(description && { flexDirection: 'column', alignItems: 'flex-start !important' }),
+              ...(optionDivider && {
+                '&:not(:last-child)': { borderBottom: '1px solid rgba(0,0,0,.23)' },
+              }),
             }}
           >
             {label}
-            {description && <Typography variant="caption" color="grey.400">{description}</Typography>}
+            {description && (
+              <Typography variant="caption" color="grey.400">
+                {description}
+              </Typography>
+            )}
           </MenuItem>
         );
       }}

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -121,7 +121,7 @@ const Autocomplete = (
             }}
           >
             {label}
-            {description && <Typography variant="caption">{description}</Typography>}
+            {description && <Typography variant="caption" color="grey.400">{description}</Typography>}
           </MenuItem>
         );
       }}

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -7,6 +7,8 @@ import TextField, { SizeTypes, ColorTypes } from './TextField';
 import InputAdornment from './InputAdornment';
 import Chip from './Chip';
 import { forwardRef, Ref } from 'react';
+import MenuItem from './MenuItem';
+import Typography from './Typography';
 
 declare module '@mui/material' {
   interface AutocompleteProps<
@@ -23,6 +25,7 @@ declare module '@mui/material' {
 export type OptionsType = {
   id: number | string;
   value: string;
+  description?: string;
   disabled?: boolean;
 };
 
@@ -108,6 +111,20 @@ const Autocomplete = (
           color={color}
         />
       )}
+      renderOption={(props, { value: label, description }, state) => {
+        console.log({ state });
+        return (
+          <MenuItem
+            {...props}
+            sx={{
+              ...(description && { flexDirection: 'column', alignItems: 'flex-start !important' }),
+            }}
+          >
+            {label}
+            {description && <Typography variant="caption">{description}</Typography>}
+          </MenuItem>
+        );
+      }}
       {...props}
     />
   );

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -114,7 +114,6 @@ const Autocomplete = (
         />
       )}
       renderOption={(props, { value: label, description }, state) => {
-        console.log({ state });
         return (
           <MenuItem
             {...props}

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -64,7 +64,6 @@ const Select = (
         renderValue: (value) => options.find((o) => o.id === +(value as number | string))?.value,
       }}
       inputProps={{ 'data-testid': testid }}
-      InputProps={{}}
       {...(props as SingleSelectProps)}
       ref={ref as Ref<HTMLDivElement>}
     >

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -6,6 +6,7 @@ import Typography from './Typography';
 
 type CommonProps = {
   options?: AutocompleteProps['options'];
+  optionDivider?: boolean;
   adornment?: AutocompleteProps<OptionsType>['adornment'];
   multiple?: boolean;
   'data-testid'?: string;
@@ -22,7 +23,14 @@ export type SingleSelectProps = Omit<
 export type SelectProps = MultipleSelectProps | SingleSelectProps;
 
 const Select = (
-  { adornment, options = [], multiple = false, 'data-testid': testid, ...props }: SelectProps,
+  {
+    adornment,
+    options = [],
+    multiple = false,
+    'data-testid': testid,
+    optionDivider,
+    ...props
+  }: SelectProps,
   ref: Ref<HTMLDivElement>
 ): JSX.Element => {
   if (multiple) {
@@ -64,10 +72,23 @@ const Select = (
           key={id}
           value={id}
           disabled={disabled}
-          sx={{ ...(description && { flexDirection: 'column', alignItems: 'flex-start' }) }}
+          sx={{
+            ...(description && {
+              flexDirection: 'column',
+              alignItems: 'flex-start',
+              
+            }),
+            ...(optionDivider && {
+              '&:not(:last-child)': { borderBottom: '1px solid rgba(0,0,0,.23)' },
+            }),
+          }}
         >
           {label}
-          {description && <Typography variant="caption" color="grey.400">{description}</Typography>}
+          {description && (
+            <Typography variant="caption" color="grey.400">
+              {description}
+            </Typography>
+          )}
         </MenuItem>
       ))}
     </TextField>

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -40,6 +40,7 @@ const Select = (
         options={options}
         disableClearable
         data-testid={testid}
+        optionDivider={optionDivider}
         {...(props as MultipleSelectProps)}
         ref={ref}
       />

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -67,7 +67,7 @@ const Select = (
           sx={{ ...(description && { flexDirection: 'column', alignItems: 'flex-start' }) }}
         >
           {label}
-          {description && <Typography variant="caption">{description}</Typography>}
+          {description && <Typography variant="caption" color="grey.400">{description}</Typography>}
         </MenuItem>
       ))}
     </TextField>

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -2,6 +2,7 @@ import { MenuItem } from '@mui/material';
 import TextField, { TextFieldProps } from './TextField';
 import Autocomplete, { AutocompleteProps, OptionsType } from './Autocomplete';
 import { forwardRef, Ref } from 'react';
+import Typography from './Typography';
 
 type CommonProps = {
   options?: AutocompleteProps['options'];
@@ -51,14 +52,22 @@ const Select = (
             horizontal: 'left',
           },
         },
+        renderValue: (value) => options.find((o) => o.id === +(value as number | string))?.value,
       }}
       inputProps={{ 'data-testid': testid }}
+      InputProps={{}}
       {...(props as SingleSelectProps)}
       ref={ref as Ref<HTMLDivElement>}
     >
-      {options.map(({ id, value: label, disabled }) => (
-        <MenuItem key={id} value={id} disabled={disabled}>
+      {options.map(({ id, value: label, description, disabled }) => (
+        <MenuItem
+          key={id}
+          value={id}
+          disabled={disabled}
+          sx={{ ...(description && { flexDirection: 'column', alignItems: 'flex-start' }) }}
+        >
           {label}
+          {description && <Typography variant="caption">{description}</Typography>}
         </MenuItem>
       ))}
     </TextField>

--- a/stories/Inputs/Select.stories.tsx
+++ b/stories/Inputs/Select.stories.tsx
@@ -125,6 +125,16 @@ MultipleSelect.args = {
   placeholder: 'Select',
   fullWidth: true,
 };
+
+export const MultipleSelectOptionDivider = MultiSelectTemplate.bind({});
+MultipleSelectOptionDivider.args = {
+  multiple: true,
+  placeholder: 'Select',
+  fullWidth: true,
+  optionDivider: true
+};
+
+
 export const MultipleSelectOptionDescription = MultiSelectTemplate.bind({});
 MultipleSelectOptionDescription.args = {
   multiple: true,

--- a/stories/Inputs/Select.stories.tsx
+++ b/stories/Inputs/Select.stories.tsx
@@ -87,6 +87,12 @@ StartAdornment.args = {
   adornment: 'Kg',
 };
 
+export const OptionDivider = SelectTemplate.bind({});
+OptionDivider.args = {
+  helperText: 'Helper text',
+  optionDivider: true
+};
+
 export const OptionDescription = SelectTemplate.bind({});
 OptionDescription.args = {
   helperText: 'Helper text',

--- a/stories/Inputs/Select.stories.tsx
+++ b/stories/Inputs/Select.stories.tsx
@@ -35,32 +35,31 @@ const SelectTemplate: Story<SelectProps> = (args) => {
   args.value = selectValue;
   args.onChange = (e: ChangeEvent<HTMLInputElement>) => setSelectValue(e.target.value);
 
-  return (
-    <Select
-      {...args}
-      options={[
-        { id: 0, value: 'Select...' },
-        { id: 1, value: 'Option 1' },
-        { id: 2, value: 'Option 2' },
-        { id: 3, value: 'Option 3' },
-        { id: 4, value: 'Option 4' },
-      ]}
-    />
-  );
+  if (!args.options) {
+    args.options = [
+      { id: 0, value: 'Select...' },
+      { id: 1, value: 'Option 1' },
+      { id: 2, value: 'Option 2' },
+      { id: 3, value: 'Option 3' },
+      { id: 4, value: 'Option 4' },
+    ];
+  }
+
+  return <Select {...args} />;
 };
 
 const MultiSelectTemplate: Story<AutocompleteProps> = (args) => {
-  return (
-    <Select
-      {...args}
-      options={[
-        { id: 1, value: 'Option 1' },
-        { id: 2, value: 'Option 2' },
-        { id: 3, value: 'Option 3' },
-        { id: 4, value: 'Option 4' },
-      ]}
-    />
-  );
+  if (!args.options) {
+    args.options = [
+      { id: 0, value: 'Select...' },
+      { id: 1, value: 'Option 1' },
+      { id: 2, value: 'Option 2' },
+      { id: 3, value: 'Option 3' },
+      { id: 4, value: 'Option 4' },
+    ];
+  }
+
+  return <Select {...args} />;
 };
 
 export const Default = SelectTemplate.bind({});
@@ -88,6 +87,18 @@ StartAdornment.args = {
   adornment: 'Kg',
 };
 
+export const OptionDescription = SelectTemplate.bind({});
+OptionDescription.args = {
+  helperText: 'Helper text',
+  options: [
+    { id: 0, value: 'Select...' },
+    { id: 1, value: 'Option 1', description: 'lorem ipsum dolor' },
+    { id: 2, value: 'Option 2', description: 'lorem ipsum dolor' },
+    { id: 3, value: 'Option 3', description: 'lorem ipsum dolor' },
+    { id: 4, value: 'Option 4', description: 'lorem ipsum dolor' },
+  ],
+};
+
 export const Disabled = SelectTemplate.bind({});
 Disabled.args = {
   helperText: 'Helper text',
@@ -107,6 +118,19 @@ MultipleSelect.args = {
   multiple: true,
   placeholder: 'Select',
   fullWidth: true,
+};
+export const MultipleSelectOptionDescription = MultiSelectTemplate.bind({});
+MultipleSelectOptionDescription.args = {
+  multiple: true,
+  placeholder: 'Select',
+  fullWidth: true,
+  options: [
+    { id: 0, value: 'Select...' },
+    { id: 1, value: 'Option 1', description: 'lorem ipsum dolor' },
+    { id: 2, value: 'Option 2', description: 'lorem ipsum dolor' },
+    { id: 3, value: 'Option 3', description: 'lorem ipsum dolor' },
+    { id: 4, value: 'Option 4', description: 'lorem ipsum dolor' },
+  ],
 };
 
 export const MultipleSelectLargeWhite = MultiSelectTemplate.bind({});


### PR DESCRIPTION
## Background

Why are these changes needed?
Lyyti portal needs a possibility to add a little description to each select option

## 💡 Features

- new `description` optional prop for select options
- new `optionDivider` optional prop for select options