### PR TITLE
Autocomplete name prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.4.7",
+      "version": "1.4.8",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "engines": {
     "node": "^18",
     "npm": "^8"

--- a/src/components/Autocomplete.tsx
+++ b/src/components/Autocomplete.tsx
@@ -2,6 +2,7 @@ import {
   Autocomplete as MuiAutocomplete,
   ChipTypeMap,
   AutocompleteProps as MuiAutocompleteProps,
+  TextFieldProps,
 } from '@mui/material';
 import TextField, { SizeTypes, ColorTypes } from './TextField';
 import InputAdornment from './InputAdornment';
@@ -45,6 +46,7 @@ export interface AutocompleteProps<T = OptionsType>
   optionDivider?: boolean;
   'data-testid'?: string;
   ref?: Ref<HTMLDivElement>;
+  name?: string;
 }
 
 const Autocomplete = (
@@ -64,6 +66,7 @@ const Autocomplete = (
     optionDivider,
     'data-testid': testid,
     sx = {},
+    name,
     ...props
   }: AutocompleteProps,
   ref: Ref<HTMLDivElement>
@@ -100,6 +103,7 @@ const Autocomplete = (
           error={error}
           helperText={helperText}
           placeholder={placeholder}
+          name={name}
           InputProps={{
             ...params.InputProps,
             startAdornment: (


### PR DESCRIPTION
## Background

We need to be able to give a name to the input.

## 💡 Feature 1

- Add name prop to Autocomplete component
