### PR TITLE
Max old space size in "build package" action

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -60,6 +60,8 @@ jobs:
         run: |
           npm ci
           npm run build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
       - name: Publish npm
         run: npm publish ./dist
         env:


### PR DESCRIPTION

## Background

This PR adds max old space size node option to package build step in github action. Apparently it's not only needed in quality checks now but also for building the package.