### PR TITLE
added max old space size flag to another build action

### DIFF
--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -44,3 +44,5 @@ jobs:
         run: npm ci
       - name: Build package
         run: npm run build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
## Background
This PR adds max old space size node option to package build step in github action in another place not spotted in previous PR. 
Now I made sure to include all actions that build a package to have this flag applied.