### PR TITLE
Make ToggleButtonGroup exportable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "engines": {
     "node": "^18",
     "npm": "^8"

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,4 +75,6 @@ export { default as TableBody } from '@mui/material/TableBody';
 export { default as TableCell } from '@mui/material/TableCell';
 export { default as TableFooter } from '@mui/material/TableFooter';
 export { default as TableRow } from '@mui/material/TableRow';
+export { default as ToggleButtonGroup } from './components/ToggleButtonGroup';
+export type { ToggleButtonOption } from './components/ToggleButtonGroup';
 export { useTheme } from '@mui/system';


### PR DESCRIPTION
## Background

My previous PR didn't include export in index.ts file so ToggleButtonGroup was unusable in different projects.