### PR TITLE
Update for style calls in ToggleButtonGroup

### DIFF
--- a/src/components/ToggleButtonGroup.tsx
+++ b/src/components/ToggleButtonGroup.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@mui/material/styles';
 import { ToggleButtonGroup as MuiToggleButtonGroup, ToggleButton as MuiToggleButton, type SxProps as MuiSxProps, type ToggleButtonGroupProps as MuiToggleButtonGroupProps } from "@mui/material"
 
 export interface ToggleButtonOption {
@@ -26,8 +25,6 @@ const ToggleButtonGroup = ({
   testId,
   ...props
 }: ToggleButtonGroupProps) => {
-  const theme = useTheme();
-
   return <MuiToggleButtonGroup
     data-testid={testId}
     value={value}
@@ -35,14 +32,15 @@ const ToggleButtonGroup = ({
     onChange={onChange}
     aria-label={ariaLabel ?? 'toggle button group'}
     sx={{
-      color: `${theme.palette.primary.main} !important`,
+      color: theme => theme.palette.primary.main,
       height: '40px',
-      border: `1px solid ${theme.palette.primary.main}`,
+      border: theme => `1px solid ${theme.palette.primary.main}`,
       '& .MuiToggleButton-root': {
-        width: '130px', color:theme.palette.primary.main 
+        width: '130px', 
+        color: theme => theme.palette.primary.main 
       },
       '& .Mui-selected, & .Mui-selected:hover': {
-        bgcolor: `${theme.palette.primary.main} !important`,
+        bgcolor: theme => `${theme.palette.primary.main} !important`,
         color: 'white !important',
       },
       ...sx


### PR DESCRIPTION
## Background

Simply remove `useTheme` hook from `ToggleButtonGroup` component.