### PR TITLE
InputLabelProps in DatePicker and TimePicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "engines": {
     "node": "^18",
     "npm": "^8"

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -3,7 +3,7 @@ import {
   DatePickerProps as MuiDatepickerProps,
 } from '@mui/x-date-pickers/DatePicker';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import type { FormHelperTextProps, InputAdornmentProps as MuiInputAdornmentProps } from '@mui/material';
+import type { FormHelperTextProps, InputLabelProps, InputAdornmentProps as MuiInputAdornmentProps } from '@mui/material';
 
 import Calendar from '../icons/Calendar';
 import { TextInputProps } from './TextField';
@@ -14,6 +14,7 @@ export interface DatePickerProps<TDate = unknown> extends Omit<MuiDatepickerProp
   FormHelperTextProps?: FormHelperTextProps;
   InputProps?: Partial<TextInputProps>;
   InputAdornmentProps?: Partial<MuiInputAdornmentProps>;
+  InputLabelProps?: Partial<InputLabelProps>
   'data-testid'?: string;
 }
 
@@ -30,6 +31,7 @@ const DatePicker = <TDate = unknown>(
     allowAllYears = false,
     InputProps = { color: 'primary', id: 'datepicker' },
     InputAdornmentProps = {},
+    InputLabelProps,
     helperText,
     FormHelperTextProps,
     ...props
@@ -85,7 +87,7 @@ const DatePicker = <TDate = unknown>(
             }),
           },
         },
-        textField: {InputProps, helperText, FormHelperTextProps},
+        textField: {InputProps, helperText, FormHelperTextProps, InputLabelProps},
         inputAdornment: {
           ...InputAdornmentProps
         },

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -15,7 +15,7 @@ export interface TimePickerProps<TDate = unknown> extends Omit<MuiTimePickerProp
   'data-testid'?: string;
 }
 
-const TimePicker = <TDate = unknown>({ ampm = false, InputProps = {}, InputAdornmentProps = {}, OpenPickerButtonProps = {}, helperText, FormHelperTextProps, ...props }: TimePickerProps<TDate>): JSX.Element => {
+const TimePicker = <TDate = unknown>({ ampm = false, InputProps = {}, InputAdornmentProps = {}, OpenPickerButtonProps = {}, helperText, FormHelperTextProps, InputLabelProps, ...props }: TimePickerProps<TDate>): JSX.Element => {
   return (
     <MuiTimePicker
       ampm={ampm}

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -2,7 +2,7 @@ import {
   TimePicker as MuiTimePicker,
   TimePickerProps as MuiTimePickerProps,
 } from '@mui/x-date-pickers/TimePicker';
-import type { FormHelperTextProps, InputAdornmentProps as MuiInputAdornmentProps } from '@mui/material';
+import type { FormHelperTextProps, InputLabelProps, InputAdornmentProps as MuiInputAdornmentProps } from '@mui/material';
 import { TextInputProps } from './TextField';
 
 export interface TimePickerProps<TDate = unknown> extends Omit<MuiTimePickerProps<TDate>, 'renderInput' | 'InputProps'> {
@@ -10,6 +10,7 @@ export interface TimePickerProps<TDate = unknown> extends Omit<MuiTimePickerProp
   helperText?: string;
   FormHelperTextProps?: FormHelperTextProps;
   InputAdornmentProps?: Partial<MuiInputAdornmentProps>;
+  InputLabelProps?: Partial<InputLabelProps>;
   OpenPickerButtonProps?: Record<string, unknown>;
   'data-testid'?: string;
 }
@@ -19,7 +20,7 @@ const TimePicker = <TDate = unknown>({ ampm = false, InputProps = {}, InputAdorn
     <MuiTimePicker
       ampm={ampm}
       slotProps={{
-        textField: {InputProps, helperText, FormHelperTextProps},
+        textField: {InputProps, helperText, FormHelperTextProps, InputLabelProps},
         inputAdornment: {
           sx: {
             ml: '0px',


### PR DESCRIPTION
## Background

This PR adds `InputLabelProps` in `DatePicker` and `TimePicker` components to be able to customise labels for those fields.