### PR TITLE
Update required npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "engines": {
     "node": "^18",
-    "npm": "^8"
+    "npm": "^9"
   },
   "scripts": {
     "dev": "storybook dev -p 6006",


### PR DESCRIPTION
## Background 📜

Why are these changes needed?
Current Node LTS version uses npm version 9, whereas design system config requires npm version 8.