### PR TITLE
[REVERT] build(deps): bump @mui/x-date-pickers from 6.4.0 to 6.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mui/material": "5.14.10",
         "@mui/x-data-grid": "6.13.0",
         "@mui/x-data-grid-pro": "6.7.0",
-        "@mui/x-date-pickers": "6.16.0",
+        "@mui/x-date-pickers": "6.4.0",
         "@mui/x-license-pro": "6.10.2"
       },
       "devDependencies": {
@@ -5609,15 +5609,14 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.16.0.tgz",
-      "integrity": "sha512-5xN/OuVtcy/bX/Yx4cJrGWLmHTMTZkufhQMtInFOM8u93TJJSPwA7X86vQdl6OztYNyYKnEpxNKxSrxcDHfKFQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.4.0.tgz",
+      "integrity": "sha512-EdKj+TVaEvx+nIljsv1BlDOYYwcMWVYB+ZMRoOCStFojY5uuDzhttQAP6DbsAPPrpKt1lzyecIukLfmIfIGcsA==",
       "dependencies": {
-        "@babel/runtime": "^7.22.15",
-        "@mui/base": "^5.0.0-beta.14",
-        "@mui/utils": "^5.14.8",
-        "@types/react-transition-group": "^4.4.6",
-        "clsx": "^2.0.0",
+        "@babel/runtime": "^7.21.0",
+        "@mui/utils": "^5.12.3",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
         "react-transition-group": "^4.4.5"
       },
@@ -5631,6 +5630,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
+        "@mui/base": "^5.0.0-alpha.87",
         "@mui/material": "^5.8.6",
         "@mui/system": "^5.8.0",
         "date-fns": "^2.25.0",
@@ -5640,8 +5640,8 @@
         "moment": "^2.29.4",
         "moment-hijri": "^2.1.2",
         "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -5671,14 +5671,6 @@
         "moment-jalaali": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mui/x-date-pickers/node_modules/clsx": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-      "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@mui/x-license-pro": {
@@ -38219,24 +38211,16 @@
       }
     },
     "@mui/x-date-pickers": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.16.0.tgz",
-      "integrity": "sha512-5xN/OuVtcy/bX/Yx4cJrGWLmHTMTZkufhQMtInFOM8u93TJJSPwA7X86vQdl6OztYNyYKnEpxNKxSrxcDHfKFQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.4.0.tgz",
+      "integrity": "sha512-EdKj+TVaEvx+nIljsv1BlDOYYwcMWVYB+ZMRoOCStFojY5uuDzhttQAP6DbsAPPrpKt1lzyecIukLfmIfIGcsA==",
       "requires": {
-        "@babel/runtime": "^7.22.15",
-        "@mui/base": "^5.0.0-beta.14",
-        "@mui/utils": "^5.14.8",
-        "@types/react-transition-group": "^4.4.6",
-        "clsx": "^2.0.0",
+        "@babel/runtime": "^7.21.0",
+        "@mui/utils": "^5.12.3",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
         "react-transition-group": "^4.4.5"
-      },
-      "dependencies": {
-        "clsx": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-          "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q=="
-        }
       }
     },
     "@mui/x-license-pro": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mui/material": "5.14.10",
     "@mui/x-data-grid": "6.13.0",
     "@mui/x-data-grid-pro": "6.7.0",
-    "@mui/x-date-pickers": "6.16.0",
+    "@mui/x-date-pickers": "6.4.0",
     "@mui/x-license-pro": "6.10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Background

Why are these changes needed?
Latest update of @mui/x-date-pickers has broken many tests in Lyyti Portal - let's revert it for now so it's not a blocking issue and try to fix it afterwards