### PR TITLE
Add required prop to DatePicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "engines": {
     "node": "^18",
     "npm": "^9"

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -4,23 +4,29 @@ import {
 } from '@mui/x-date-pickers/DatePicker';
 import { DesktopDatePicker as MuiDesktopDatePicker } from '@mui/x-date-pickers/DesktopDatePicker';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
-import type { FormHelperTextProps, InputLabelProps, InputAdornmentProps as MuiInputAdornmentProps } from '@mui/material';
+import type {
+  FormHelperTextProps,
+  InputLabelProps,
+  InputAdornmentProps as MuiInputAdornmentProps,
+} from '@mui/material';
 
 import Calendar from '../icons/Calendar';
 import { TextInputProps } from './TextField';
 
-export interface DatePickerProps<TDate = unknown> extends Omit<MuiDatepickerProps<TDate>, 'renderInput' | 'InputProps'> {
+export interface DatePickerProps<TDate = unknown>
+  extends Omit<MuiDatepickerProps<TDate>, 'renderInput' | 'InputProps'> {
+  required?: boolean;
   allowAllYears?: boolean;
   helperText?: string;
   FormHelperTextProps?: FormHelperTextProps;
   InputProps?: Partial<TextInputProps>;
   InputAdornmentProps?: Partial<MuiInputAdornmentProps>;
-  InputLabelProps?: Partial<InputLabelProps>
+  InputLabelProps?: Partial<InputLabelProps>;
   'data-testid'?: string;
   variant?: 'desktop' | 'responsive';
 }
 
-export { AdapterDayjs }
+export { AdapterDayjs };
 
 const isDisallowedYear = (date: any) => {
   const year = new Date(date).getFullYear();
@@ -28,18 +34,17 @@ const isDisallowedYear = (date: any) => {
   return year < 2006 || year > maxYear;
 };
 
-const DatePicker = <TDate = unknown>(
-  {
-    allowAllYears = false,
-    InputProps = { color: 'primary', id: 'datepicker' },
-    InputAdornmentProps = {},
-    InputLabelProps,
-    helperText,
-    FormHelperTextProps,
-    variant = 'responsive',
-    ...props
-  }: DatePickerProps<TDate>,
-): JSX.Element => {
+const DatePicker = <TDate = unknown,>({
+  allowAllYears = false,
+  InputProps = { color: 'primary', id: 'datepicker' },
+  InputAdornmentProps = {},
+  InputLabelProps,
+  helperText,
+  FormHelperTextProps,
+  variant = 'responsive',
+  required = false,
+  ...props
+}: DatePickerProps<TDate>): JSX.Element => {
   const MuiDatePicker = variant === 'desktop' ? MuiDesktopDatePicker : MuiResponsiveDatePicker;
   return (
     <MuiDatePicker
@@ -91,12 +96,12 @@ const DatePicker = <TDate = unknown>(
             }),
           },
         },
-        textField: {InputProps, helperText, FormHelperTextProps, InputLabelProps},
+        textField: { InputProps, helperText, FormHelperTextProps, InputLabelProps, required },
         inputAdornment: {
-          ...InputAdornmentProps
+          ...InputAdornmentProps,
         },
       }}
-      shouldDisableYear={(year) => !allowAllYears ? isDisallowedYear(year) : false}
+      shouldDisableYear={(year) => (!allowAllYears ? isDisallowedYear(year) : false)}
       {...props}
     />
   );


### PR DESCRIPTION
## Background

**Why are these changes needed?**
Currently, it's impossible to pass `required` prop to `slotProps.textField`, thus we can't indicate with asterisk that a field is required.


