### PR TITLE
Revert "build(deps): bump @mui/x-date-pickers from 6.4.0 to 6.18.4"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@mui/material": "5.14.17",
         "@mui/x-data-grid": "6.13.0",
         "@mui/x-data-grid-pro": "6.7.0",
-        "@mui/x-date-pickers": "6.18.4",
+        "@mui/x-date-pickers": "6.4.0",
         "@mui/x-license-pro": "6.10.2",
         "@mui/x-tree-view": "6.17.0"
       },
@@ -4258,15 +4258,14 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "6.18.4",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.18.4.tgz",
-      "integrity": "sha512-YqJ6lxZHBIt344B3bvRAVbdYSQz4dcmJQXGcfvJTn26VdKjpgzjAqwhlbQhbAt55audJOWzGB99ImuQuljDROA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.4.0.tgz",
+      "integrity": "sha512-EdKj+TVaEvx+nIljsv1BlDOYYwcMWVYB+ZMRoOCStFojY5uuDzhttQAP6DbsAPPrpKt1lzyecIukLfmIfIGcsA==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/base": "^5.0.0-beta.22",
-        "@mui/utils": "^5.14.16",
-        "@types/react-transition-group": "^4.4.8",
-        "clsx": "^2.0.0",
+        "@babel/runtime": "^7.21.0",
+        "@mui/utils": "^5.12.3",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
         "react-transition-group": "^4.4.5"
       },
@@ -4280,6 +4279,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
+        "@mui/base": "^5.0.0-alpha.87",
         "@mui/material": "^5.8.6",
         "@mui/system": "^5.8.0",
         "date-fns": "^2.25.0",
@@ -4289,8 +4289,8 @@
         "moment": "^2.29.4",
         "moment-hijri": "^2.1.2",
         "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -4320,6 +4320,14 @@
         "moment-jalaali": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@mui/x-license-pro": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mui/material": "5.14.17",
     "@mui/x-data-grid": "6.13.0",
     "@mui/x-data-grid-pro": "6.7.0",
-    "@mui/x-date-pickers": "6.18.4",
+    "@mui/x-date-pickers": "6.4.0",
     "@mui/x-license-pro": "6.10.2",
     "@mui/x-tree-view": "6.17.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "engines": {
     "node": "^18",
     "npm": "^9"


### PR DESCRIPTION
Reverts @mui/x-date-pickers back to 6.4.0 due to lots of failing tests caused by this error:
`TypeError: value.endOf is not a function`

Further investigation and debuging will be taken in the future within [this ticket](https://lyytidev.atlassian.net/browse/NG-2992) scope