### PR TITLE
Snackbar enable actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lyyti/design-system",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lyyti/design-system",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.11.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@lyyti/design-system",
   "description": "Lyyti Design System",
   "homepage": "https://lyytioy.github.io/lyyti-design-system",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "engines": {
     "node": "^18",
     "npm": "^9"

--- a/src/components/AlertBase.tsx
+++ b/src/components/AlertBase.tsx
@@ -12,7 +12,15 @@ const AlertBase = (
   { severity = 'success', variant = 'standard', ...props }: AlertBaseProps,
   ref: Ref<HTMLDivElement>
 ): JSX.Element => {
-  return <MuiAlert ref={ref} severity={severity} variant={variant} {...props} />;
+  return (
+    <MuiAlert
+      ref={ref}
+      severity={severity}
+      variant={variant}
+      sx={{ alignItems: 'center', '& .MuiAlert-action': { pt: 0, pl: 5 } }}
+      {...props}
+    />
+  );
 };
 
 export default forwardRef(AlertBase);

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -1,4 +1,4 @@
-import { Snackbar as MuiSnackbar, SnackbarProps as MuiSnackbarProps } from '@mui/material';
+import { Divider, Snackbar as MuiSnackbar, SnackbarProps as MuiSnackbarProps } from '@mui/material';
 import AlertBase from './AlertBase';
 import Slide from '@mui/material/Slide';
 import { TransitionProps } from '@mui/material/transitions';
@@ -14,7 +14,7 @@ export interface SnackbarProps extends MuiSnackbarProps {
   direction?: 'right' | 'left' | 'up' | 'down';
   severity?: 'success' | 'info' | 'warning' | 'error';
   variant?: 'standard' | 'filled' | 'outlined';
-  ref?: Ref<HTMLDivElement>
+  ref?: Ref<HTMLDivElement>;
 }
 
 const Snackbar = (
@@ -28,6 +28,7 @@ const Snackbar = (
     direction = 'left',
     severity = 'success',
     variant = 'standard',
+    action,
     ...props
   }: SnackbarProps,
   ref: Ref<HTMLDivElement>
@@ -43,7 +44,7 @@ const Snackbar = (
       {...props}
     >
       <div>
-        <AlertBase color={color} severity={severity} variant={variant}>
+        <AlertBase color={color} severity={severity} variant={variant} action={action}>
           {props.message}
         </AlertBase>
       </div>

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -1,4 +1,4 @@
-import { Divider, Snackbar as MuiSnackbar, SnackbarProps as MuiSnackbarProps } from '@mui/material';
+import { Snackbar as MuiSnackbar, SnackbarProps as MuiSnackbarProps } from '@mui/material';
 import AlertBase from './AlertBase';
 import Slide from '@mui/material/Slide';
 import { TransitionProps } from '@mui/material/transitions';

--- a/stories/Feedback/Snackbar.stories.tsx
+++ b/stories/Feedback/Snackbar.stories.tsx
@@ -3,6 +3,7 @@ import { useState, SyntheticEvent } from 'react';
 import Snackbar, { SnackbarProps } from '../../src/components/Snackbar';
 import Button from '../../src/components/Button';
 import { modifyExcludedParams } from '../../.storybook/excludedParams';
+import { Box } from '@mui/material';
 
 const meta: Meta = {
   title: 'Components/Feedback/Snackbar',
@@ -50,18 +51,26 @@ const Template: StoryFn<SnackbarProps> = (args) => {
   args.onClose = handleClose;
 
   return (
-    <>
-      <Button variant="contained" color="primary" onClick={() => setShowSnackbar(true)}>
-        {'Open snackbar'}
-      </Button>
+    <Box sx={{ width: '800px', display: 'flex', justifyContent: 'center' }}>
+      <Button onClick={() => setShowSnackbar(true)}>{'Open snackbar'}</Button>
       <Snackbar {...args} />
-    </>
+    </Box>
   );
 };
 
 export const Success = Template.bind({});
 Success.args = {
   message: 'Success message',
+};
+
+export const SuccessWithAction = Template.bind({});
+SuccessWithAction.args = {
+  message: 'Success message',
+  action: (
+    <Button color="inherit" onClick={() => console.log('clicked snackbar button')} variant="text">
+      Click me
+    </Button>
+  ),
 };
 
 export const Error = Template.bind({});
@@ -86,4 +95,9 @@ Info.args = {
     horizontal: 'left',
   },
   direction: 'up',
+  action: (
+    <Button color="inherit" onClick={() => console.log('clicked snackbar button')} variant="text">
+      click me
+    </Button>
+  ),
 };


### PR DESCRIPTION
## Background

Currently actions were not working in snackbars. This PR enables adding actions. Also small improvements to alignment of snackbar/alert content.

Related to this [ticket](https://lyytidev.atlassian.net/browse/NG-2881).
