### PR TITLE
Revert "build(deps): bump @mui/x-date-pickers from 6.4.0 to 6.19.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/material": "5.15.4",
         "@mui/x-data-grid": "6.18.6",
         "@mui/x-data-grid-pro": "6.18.7",
-        "@mui/x-date-pickers": "6.19.2",
+        "@mui/x-date-pickers": "6.4.0",
         "@mui/x-license-pro": "6.10.2",
         "@mui/x-tree-view": "6.17.0"
       },
@@ -3886,15 +3886,14 @@
       }
     },
     "node_modules/@mui/x-date-pickers": {
-      "version": "6.19.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.19.2.tgz",
-      "integrity": "sha512-/bdWZabexuz+1rKG15XryxiMGb5D0XVx65NU7CZYKm/1+HuUzc0FX9smKEa/YVZnLSNsAp6SULIyPZtAKE+3AA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.4.0.tgz",
+      "integrity": "sha512-EdKj+TVaEvx+nIljsv1BlDOYYwcMWVYB+ZMRoOCStFojY5uuDzhttQAP6DbsAPPrpKt1lzyecIukLfmIfIGcsA==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@mui/base": "^5.0.0-beta.22",
-        "@mui/utils": "^5.14.16",
-        "@types/react-transition-group": "^4.4.8",
-        "clsx": "^2.0.0",
+        "@babel/runtime": "^7.21.0",
+        "@mui/utils": "^5.12.3",
+        "@types/react-transition-group": "^4.4.5",
+        "clsx": "^1.2.1",
         "prop-types": "^15.8.1",
         "react-transition-group": "^4.4.5"
       },
@@ -3908,17 +3907,18 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
+        "@mui/base": "^5.0.0-alpha.87",
         "@mui/material": "^5.8.6",
         "@mui/system": "^5.8.0",
-        "date-fns": "^2.25.0 || ^3.2.0",
+        "date-fns": "^2.25.0",
         "date-fns-jalali": "^2.13.0-0",
         "dayjs": "^1.10.7",
         "luxon": "^3.0.2",
         "moment": "^2.29.4",
         "moment-hijri": "^2.1.2",
         "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -3948,6 +3948,14 @@
         "moment-jalaali": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-date-pickers/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@mui/x-license-pro": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@mui/material": "5.15.4",
     "@mui/x-data-grid": "6.18.6",
     "@mui/x-data-grid-pro": "6.18.7",
-    "@mui/x-date-pickers": "6.19.2",
+    "@mui/x-date-pickers": "6.4.0",
     "@mui/x-license-pro": "6.10.2",
     "@mui/x-tree-view": "6.17.0"
   },


### PR DESCRIPTION
This reverts commit 19c3bf77acdfe78938858c845b5f1047d3dab7f7.

## Background
The 6.19.2 version of @mui/x-date-pickers breaks many tests in lyyti-portal, thus it needs to be reverted back to 6.4.0